### PR TITLE
build(makefile): do "build" before "test" for the "all" target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ else
 	EXTLDFLAGS =
 endif
 
-all: test build
+all: build test
 
 build: build_service_cross_without_doc build_deploy_cross_without_protos
 


### PR DESCRIPTION
Let "build" to probe the complie error firstly.