### PR TITLE
refactor(deploy): make the tasks/actions public

### DIFF
--- a/pkg/deploy/action/action.go
+++ b/pkg/deploy/action/action.go
@@ -61,55 +61,55 @@ type Action interface {
 	GetNode() *pb.Node
 }
 
-// base is the basic metadata of an action
-type base struct {
-	name              string
-	actionType        Type
-	status            Status
-	err               *pb.Error
-	logFilePath       string
-	creationTimestamp time.Time
-	node              *pb.Node
+// Base is the basic metadata of an action
+type Base struct {
+	Name              string
+	ActionType        Type
+	Status            Status
+	Err               *pb.Error
+	LogFilePath       string
+	CreationTimestamp time.Time
+	Node              *pb.Node
 }
 
-func (b *base) GetName() string {
-	return b.name
+func (b *Base) GetName() string {
+	return b.Name
 }
 
-func (b *base) GetStatus() Status {
-	return b.status
+func (b *Base) GetStatus() Status {
+	return b.Status
 }
 
-func (b *base) SetStatus(status Status) {
-	b.status = status
+func (b *Base) SetStatus(status Status) {
+	b.Status = status
 }
 
-func (b *base) GetType() Type {
-	return b.actionType
+func (b *Base) GetType() Type {
+	return b.ActionType
 }
 
-func (b *base) GetErr() *pb.Error {
-	return b.err
+func (b *Base) GetErr() *pb.Error {
+	return b.Err
 }
 
-func (b *base) SetErr(err *pb.Error) {
-	b.err = err
+func (b *Base) SetErr(err *pb.Error) {
+	b.Err = err
 }
 
-func (b *base) GetLogFilePath() string {
-	return b.logFilePath
+func (b *Base) GetLogFilePath() string {
+	return b.LogFilePath
 }
 
-func (b *base) SetLogFilePath(path string) {
-	b.logFilePath = path
+func (b *Base) SetLogFilePath(path string) {
+	b.LogFilePath = path
 }
 
-func (b *base) GetCreationTimestamp() time.Time {
-	return b.creationTimestamp
+func (b *Base) GetCreationTimestamp() time.Time {
+	return b.CreationTimestamp
 }
 
-func (b *base) GetNode() *pb.Node {
-	return b.node
+func (b *Base) GetNode() *pb.Node {
+	return b.Node
 }
 
 // GenActionLogFilePath is a helper to return a file path based on the base path and aciton name

--- a/pkg/deploy/action/deploy_etcd_action.go
+++ b/pkg/deploy/action/deploy_etcd_action.go
@@ -25,8 +25,6 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
-type deployEtcdStatus string
-
 // DeployEtcdActionConfig represents the config for a ectd deploy in a node
 type DeployEtcdActionConfig struct {
 	CaCrt           *x509.Certificate
@@ -36,11 +34,12 @@ type DeployEtcdActionConfig struct {
 	LogFileBasePath string
 }
 
-type deployEtcdAction struct {
-	base
-	caCrt        *x509.Certificate
-	caKey        crypto.Signer
-	clusterNodes []*pb.Node
+type DeployEtcdAction struct {
+	Base
+
+	CACrt        *x509.Certificate
+	CAKey        crypto.Signer
+	ClusterNodes []*pb.Node
 }
 
 // NewDeployEtcdAction returns a deploy etcd action based on the config.
@@ -59,18 +58,18 @@ func NewDeployEtcdAction(cfg *DeployEtcdActionConfig) (Action, error) {
 	}
 
 	actionName := getDeployEtcdActionName(cfg)
-	return &deployEtcdAction{
-		base: base{
-			name:              actionName,
-			actionType:        ActionTypeDeployEtcd,
-			status:            ActionPending,
-			logFilePath:       GenActionLogFilePath(cfg.LogFileBasePath, actionName),
-			creationTimestamp: time.Now(),
-			node:              cfg.Node,
+	return &DeployEtcdAction{
+		Base: Base{
+			Name:              actionName,
+			ActionType:        ActionTypeDeployEtcd,
+			Status:            ActionPending,
+			LogFilePath:       GenActionLogFilePath(cfg.LogFileBasePath, actionName),
+			CreationTimestamp: time.Now(),
+			Node:              cfg.Node,
 		},
-		caCrt:        cfg.CaCrt,
-		caKey:        cfg.CaKey,
-		clusterNodes: cfg.ClusterNodes,
+		CACrt:        cfg.CaCrt,
+		CAKey:        cfg.CaKey,
+		ClusterNodes: cfg.ClusterNodes,
 	}, nil
 }
 

--- a/pkg/deploy/action/deploy_etcd_executor.go
+++ b/pkg/deploy/action/deploy_etcd_executor.go
@@ -28,7 +28,7 @@ type deployEtcdExecutor struct {
 }
 
 func (a *deployEtcdExecutor) Execute(act Action) error {
-	etcdAction, ok := act.(*deployEtcdAction)
+	etcdAction, ok := act.(*DeployEtcdAction)
 	if !ok {
 		return fmt.Errorf("the action type is not match: should be deploy etcd action, but is %T", act)
 	}
@@ -41,22 +41,22 @@ func (a *deployEtcdExecutor) Execute(act Action) error {
 
 	config := &etcd.DeployEtcdOperationConfig{
 		Logger:       logger,
-		Node:         etcdAction.node,
-		CACrt:        etcdAction.caCrt,
-		CAKey:        etcdAction.caKey,
-		ClusterNodes: etcdAction.clusterNodes,
+		Node:         etcdAction.Node,
+		CACrt:        etcdAction.CACrt,
+		CAKey:        etcdAction.CAKey,
+		ClusterNodes: etcdAction.ClusterNodes,
 	}
 	op, err := etcd.NewDeployEtcdOperation(config)
 	if err != nil {
 		return fmt.Errorf("failed to get etcd operation, error: %v", err)
 	}
 
-	logger.Debugf("Start to deploy etcd on nodes: %s", etcdAction.node.Name)
+	logger.Debugf("Start to deploy etcd on nodes: %s", etcdAction.Node.Name)
 
-	etcdAction.status = ActionDone
+	etcdAction.Status = ActionDone
 	if err := op.Do(); err != nil {
-		etcdAction.status = ActionFailed
-		etcdAction.err = &pb.Error{
+		etcdAction.Status = ActionFailed
+		etcdAction.Err = &pb.Error{
 			Reason:     err.Error(),
 			Detail:     err.Error(),
 			FixMethods: "",

--- a/pkg/deploy/action/fetch_kube_config_action.go
+++ b/pkg/deploy/action/fetch_kube_config_action.go
@@ -30,8 +30,8 @@ type FetchKubeConfigActionConfig struct {
 }
 
 type FetchKubeConfigAction struct {
-	base
-	node       *pb.Node
+	Base
+
 	KubeConfig []byte
 }
 
@@ -57,13 +57,13 @@ func NewFetchKubeConfigAction(cfg *FetchKubeConfigActionConfig) (Action, error) 
 	}
 
 	return &FetchKubeConfigAction{
-		base: base{
-			name:              actionName,
-			actionType:        ActionTypeFetchKubeConfig,
-			status:            ActionPending,
-			logFilePath:       GenActionLogFilePath(cfg.LogFileBasePath, actionName),
-			creationTimestamp: time.Now(),
+		Base: Base{
+			Name:              actionName,
+			ActionType:        ActionTypeFetchKubeConfig,
+			Status:            ActionPending,
+			LogFilePath:       GenActionLogFilePath(cfg.LogFileBasePath, actionName),
+			CreationTimestamp: time.Now(),
+			Node:              cfg.Node,
 		},
-		node: cfg.Node,
 	}, nil
 }

--- a/pkg/deploy/action/fetch_kube_config_action_test.go
+++ b/pkg/deploy/action/fetch_kube_config_action_test.go
@@ -42,5 +42,5 @@ func TestNewFetchKubeConfigAction(t *testing.T) {
 	assert.IsType(t, &FetchKubeConfigAction{}, act)
 	assert.Equal(t, ActionTypeFetchKubeConfig, act.GetType())
 	assert.Equal(t, ActionPending, act.GetStatus())
-	assert.Equal(t, cfg.Node, act.(*FetchKubeConfigAction).node)
+	assert.Equal(t, cfg.Node, act.(*FetchKubeConfigAction).Node)
 }

--- a/pkg/deploy/action/fetch_kube_config_executor.go
+++ b/pkg/deploy/action/fetch_kube_config_executor.go
@@ -40,7 +40,7 @@ func (a *fetchKubeConfigExecutor) Execute(act Action) error {
 	// TODO: ssh to fetch kube config file from kubeCfgAction.node
 
 	// Update action
-	kubeCfgAction.status = ActionDone
+	kubeCfgAction.Status = ActionDone
 	kubeCfgAction.KubeConfig = []byte("todo: the content of kube config file")
 
 	logger.Debug("Finsih to execute action")

--- a/pkg/deploy/action/node_check_action.go
+++ b/pkg/deploy/action/node_check_action.go
@@ -30,24 +30,25 @@ type NodeCheckActionConfig struct {
 	LogFileBasePath string
 }
 
-type nodeCheckAction struct {
-	base
-	nodeCheckConfig *pb.NodeCheckConfig
-	checkItems      []*nodeCheckItem
+type NodeCheckAction struct {
+	Base
 	sync.RWMutex
+
+	NodeCheckConfig *pb.NodeCheckConfig
+	CheckItems      []*nodeCheckItem
 }
 
-type nodeCheckItemStatus string
+type NodeCheckItemStatus string
 
 const (
-	nodeCheckItemFailed    nodeCheckItemStatus = "failed"
-	nodeCheckItemSucessful nodeCheckItemStatus = "sucessful"
+	NodeCheckItemFailed    NodeCheckItemStatus = "failed"
+	NodeCheckItemSucessful NodeCheckItemStatus = "sucessful"
 )
 
 type nodeCheckItem struct {
 	name        string
 	description string
-	status      nodeCheckItemStatus
+	status      NodeCheckItemStatus
 	err         *pb.Error
 }
 
@@ -69,15 +70,15 @@ func NewNodeCheckAction(cfg *NodeCheckActionConfig) (Action, error) {
 	}
 
 	actionName := getNodeCheckActionName(cfg)
-	return &nodeCheckAction{
-		base: base{
-			name:              actionName,
-			actionType:        ActionTypeNodeCheck,
-			status:            ActionPending,
-			logFilePath:       GenActionLogFilePath(cfg.LogFileBasePath, actionName),
-			creationTimestamp: time.Now(),
+	return &NodeCheckAction{
+		Base: Base{
+			Name:              actionName,
+			ActionType:        ActionTypeNodeCheck,
+			Status:            ActionPending,
+			LogFilePath:       GenActionLogFilePath(cfg.LogFileBasePath, actionName),
+			CreationTimestamp: time.Now(),
 		},
-		nodeCheckConfig: cfg.NodeCheckConfig,
+		NodeCheckConfig: cfg.NodeCheckConfig,
 	}, nil
 }
 

--- a/pkg/deploy/action/node_check_executor.go
+++ b/pkg/deploy/action/node_check_executor.go
@@ -90,11 +90,11 @@ func ExecuteCheckScript(item check.ItemEnum, config *pb.NodeCheckConfig, checkIt
 	return checkItemStdOut, checkItemReport, nil
 }
 
-func CheckDockerExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
+func CheckDockerExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 
 	checkItemReport := newNodeCheckItem()
 	checkItemReport.status = ItemActionDoing
-	comparedDockerVersion, checkItemReport, err := ExecuteCheckScript(check.Docker, ncAction.nodeCheckConfig, checkItemReport)
+	comparedDockerVersion, checkItemReport, err := ExecuteCheckScript(check.Docker, ncAction.NodeCheckConfig, checkItemReport)
 	UpdateCheckItems(ncAction, checkItemReport)
 	if err != nil {
 		checkItemReport.status = ItemActionFailed
@@ -122,11 +122,11 @@ func newNodeCheckItem() *nodeCheckItem {
 	}
 }
 
-func CheckCPUExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
+func CheckCPUExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 
 	checkItemReport := newNodeCheckItem()
 	checkItemReport.status = ItemActionDoing
-	cpuCore, checkItemReport, err := ExecuteCheckScript(check.CPU, ncAction.nodeCheckConfig, checkItemReport)
+	cpuCore, checkItemReport, err := ExecuteCheckScript(check.CPU, ncAction.NodeCheckConfig, checkItemReport)
 	UpdateCheckItems(ncAction, checkItemReport)
 	if err != nil {
 		checkItemReport.status = ItemActionFailed
@@ -146,11 +146,11 @@ func CheckCPUExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
-func CheckKernelExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
+func CheckKernelExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 
 	checkItemReport := newNodeCheckItem()
 	checkItemReport.status = ItemActionDoing
-	kernelVersion, checkItemReport, err := ExecuteCheckScript(check.Kernel, ncAction.nodeCheckConfig, checkItemReport)
+	kernelVersion, checkItemReport, err := ExecuteCheckScript(check.Kernel, ncAction.NodeCheckConfig, checkItemReport)
 	UpdateCheckItems(ncAction, checkItemReport)
 	if err != nil {
 		checkItemReport.status = ItemActionFailed
@@ -170,11 +170,11 @@ func CheckKernelExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
-func CheckMemoryExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
+func CheckMemoryExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 
 	checkItemReport := newNodeCheckItem()
 	checkItemReport.status = ItemActionDoing
-	memoryCap, checkItemReport, err := ExecuteCheckScript(check.Memory, ncAction.nodeCheckConfig, checkItemReport)
+	memoryCap, checkItemReport, err := ExecuteCheckScript(check.Memory, ncAction.NodeCheckConfig, checkItemReport)
 	UpdateCheckItems(ncAction, checkItemReport)
 	if err != nil {
 		checkItemReport.status = ItemActionFailed
@@ -194,11 +194,11 @@ func CheckMemoryExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
-func CheckRootDiskExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
+func CheckRootDiskExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 
 	checkItemReport := newNodeCheckItem()
 	checkItemReport.status = ItemActionDoing
-	rootDiskVolume, checkItemReport, err := ExecuteCheckScript(check.Disk, ncAction.nodeCheckConfig, checkItemReport)
+	rootDiskVolume, checkItemReport, err := ExecuteCheckScript(check.Disk, ncAction.NodeCheckConfig, checkItemReport)
 	UpdateCheckItems(ncAction, checkItemReport)
 	if err != nil {
 		checkItemReport.status = ItemActionFailed
@@ -218,11 +218,11 @@ func CheckRootDiskExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
-func CheckDistributionExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
+func CheckDistributionExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 
 	checkItemReport := newNodeCheckItem()
 	checkItemReport.status = ItemActionDoing
-	disName, checkItemReport, err := ExecuteCheckScript(check.Distribution, ncAction.nodeCheckConfig, checkItemReport)
+	disName, checkItemReport, err := ExecuteCheckScript(check.Distribution, ncAction.NodeCheckConfig, checkItemReport)
 	UpdateCheckItems(ncAction, checkItemReport)
 	if err != nil {
 		checkItemReport.status = ItemActionFailed
@@ -243,7 +243,7 @@ func CheckDistributionExecutor(ncAction *nodeCheckAction, wg *sync.WaitGroup) {
 }
 
 func (a *nodeCheckExecutor) Execute(act Action) error {
-	nodeCheckAction, ok := act.(*nodeCheckAction)
+	nodeCheckAction, ok := act.(*NodeCheckAction)
 	if !ok {
 		return fmt.Errorf("the action type is not match: should be node check action, but is %T", act)
 	}
@@ -266,20 +266,20 @@ func (a *nodeCheckExecutor) Execute(act Action) error {
 	go CheckDistributionExecutor(nodeCheckAction, &wg)
 	wg.Wait()
 
-	nodeCheckAction.status = ActionDone
+	nodeCheckAction.Status = ActionDone
 	logger.Debug("Finish to execute node check action")
 	return nil
 }
 
 // update check items with matching name
-func UpdateCheckItems(checkAction *nodeCheckAction, report *nodeCheckItem) {
+func UpdateCheckItems(checkAction *NodeCheckAction, report *nodeCheckItem) {
 
 	checkAction.Lock()
 	defer checkAction.Unlock()
 
 	updatedFlag := false
 
-	for _, item := range checkAction.checkItems {
+	for _, item := range checkAction.CheckItems {
 		if item.name == report.name {
 			updatedFlag = true
 			item.err = report.err
@@ -289,6 +289,6 @@ func UpdateCheckItems(checkAction *nodeCheckAction, report *nodeCheckItem) {
 	}
 
 	if updatedFlag == false {
-		checkAction.checkItems = append(checkAction.checkItems, report)
+		checkAction.CheckItems = append(checkAction.CheckItems, report)
 	}
 }

--- a/pkg/deploy/task/deploy_etcd_processor.go
+++ b/pkg/deploy/task/deploy_etcd_processor.go
@@ -41,7 +41,7 @@ func (p *deployEtcdProcessor) SplitTask(t Task) error {
 
 	logger.Debug("Start to split deploy etcd task")
 
-	etcdTask := t.(*deployEtcdTask)
+	etcdTask := t.(*DeployEtcdTask)
 
 	// generate etcd ca cert and key and put it into every action
 	caCertConfig := etcd.GetCaCrtConfig()
@@ -52,14 +52,14 @@ func (p *deployEtcdProcessor) SplitTask(t Task) error {
 
 	// split task into actions: will create a action for every node, the action type
 	// is ActionTypeDeployEtcd
-	actions := make([]action.Action, 0, len(etcdTask.nodes))
-	for _, node := range etcdTask.nodes {
+	actions := make([]action.Action, 0, len(etcdTask.Nodes))
+	for _, node := range etcdTask.Nodes {
 		actionCfg := &action.DeployEtcdActionConfig{
 			CaCrt:           caCrt,
 			CaKey:           cakey,
 			Node:            node,
-			ClusterNodes:    etcdTask.nodes,
-			LogFileBasePath: etcdTask.logFilePath,
+			ClusterNodes:    etcdTask.Nodes,
+			LogFileBasePath: etcdTask.LogFilePath,
 		}
 		act, err := action.NewDeployEtcdAction(actionCfg)
 		if err != nil {
@@ -67,7 +67,7 @@ func (p *deployEtcdProcessor) SplitTask(t Task) error {
 		}
 		actions = append(actions, act)
 	}
-	etcdTask.actions = actions
+	etcdTask.Actions = actions
 
 	logger.Debugf("Finish to split deploy etcd task: %d actions", len(actions))
 
@@ -80,12 +80,12 @@ func (p *deployEtcdProcessor) verifyTask(t Task) error {
 		return consts.ErrEmptyTask
 	}
 
-	etcdTask, ok := t.(*deployEtcdTask)
+	etcdTask, ok := t.(*DeployEtcdTask)
 	if !ok {
 		return fmt.Errorf("%s: %T", consts.MsgTaskTypeMismatched, t)
 	}
 
-	if len(etcdTask.nodes) == 0 {
+	if len(etcdTask.Nodes) == 0 {
 		return fmt.Errorf("nodes is empty")
 	}
 

--- a/pkg/deploy/task/deploy_etcd_task.go
+++ b/pkg/deploy/task/deploy_etcd_task.go
@@ -31,9 +31,10 @@ type DeployEtcdTaskConfig struct {
 	Parent          string
 }
 
-type deployEtcdTask struct {
-	base
-	nodes []*pb.Node
+type DeployEtcdTask struct {
+	Base
+
+	Nodes []*pb.Node
 }
 
 // NewDeployEtcdTask returns a deploy etcd task based on the config.
@@ -52,17 +53,17 @@ func NewDeployEtcdTask(taskName string, taskConfig *DeployEtcdTaskConfig) (Task,
 		return nil, err
 	}
 
-	task := &deployEtcdTask{
-		base: base{
-			name:              taskName,
-			taskType:          TaskTypeDeployEtcd,
-			status:            TaskPending,
-			logFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
-			creationTimestamp: time.Now(),
-			priority:          taskConfig.Priority,
-			parent:            taskConfig.Parent,
+	task := &DeployEtcdTask{
+		Base: Base{
+			Name:              taskName,
+			TaskType:          TaskTypeDeployEtcd,
+			Status:            TaskPending,
+			LogFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
+			CreationTimestamp: time.Now(),
+			Priority:          taskConfig.Priority,
+			Parent:            taskConfig.Parent,
 		},
-		nodes: taskConfig.Nodes,
+		Nodes: taskConfig.Nodes,
 	}
 
 	return task, nil

--- a/pkg/deploy/task/deploy_processor.go
+++ b/pkg/deploy/task/deploy_processor.go
@@ -45,10 +45,10 @@ func (p *deployProcessor) SplitTask(t Task) error {
 	var subTasks []Task
 
 	// first collect all roles and their related nodes
-	roles := p.groupByRole(deployTask.nodeConfigs)
+	roles := p.groupByRole(deployTask.NodeConfigs)
 
 	// create the init sub tasks with priority = 10
-	initTask, err := p.createInitSubTask(deployTask, deployTask.logFilePath, 10)
+	initTask, err := p.createInitSubTask(deployTask, deployTask.LogFilePath, 10)
 	if err != nil {
 		err = fmt.Errorf("failed to create init sub tasks: %s", err)
 		logger.Error(err)
@@ -58,7 +58,7 @@ func (p *deployProcessor) SplitTask(t Task) error {
 
 	// create the deploy etcd sub tasks with priority = 20
 	if nodes, ok := roles[consts.NodeRoleEtcd]; ok {
-		etcdTask, err := p.createDeploySubTask(consts.NodeRoleEtcd, deployTask.name, nodes, deployTask.logFilePath, 20)
+		etcdTask, err := p.createDeploySubTask(consts.NodeRoleEtcd, deployTask.Name, nodes, deployTask.LogFilePath, 20)
 		if err != nil {
 			err = fmt.Errorf("failed to create deploy etcd sub tasks: %s", err)
 			logger.Error(err)
@@ -69,7 +69,7 @@ func (p *deployProcessor) SplitTask(t Task) error {
 
 	// create the deploy master sub tasks with priority = 30
 	if nodes, ok := roles[consts.NodeRoleMaster]; ok {
-		masterTask, err := p.createDeploySubTask(consts.NodeRoleMaster, deployTask.name, nodes, deployTask.logFilePath, 30)
+		masterTask, err := p.createDeploySubTask(consts.NodeRoleMaster, deployTask.Name, nodes, deployTask.LogFilePath, 30)
 		if err != nil {
 			err = fmt.Errorf("failed to create deploy master sub tasks: %s", err)
 			logger.Error(err)
@@ -80,7 +80,7 @@ func (p *deployProcessor) SplitTask(t Task) error {
 
 	// create the deploy worker sub tasks with priority = 40
 	if nodes, ok := roles[consts.NodeRoleWorker]; ok {
-		workerTask, err := p.createDeploySubTask(consts.NodeRoleWorker, deployTask.name, nodes, deployTask.logFilePath, 40)
+		workerTask, err := p.createDeploySubTask(consts.NodeRoleWorker, deployTask.Name, nodes, deployTask.LogFilePath, 40)
 		if err != nil {
 			err = fmt.Errorf("failed to create deploy worker sub tasks: %s", err)
 			logger.Error(err)
@@ -91,7 +91,7 @@ func (p *deployProcessor) SplitTask(t Task) error {
 
 	// create the deploy ingress sub tasks with priority = 50
 	if nodes, ok := roles[consts.NodeRoleIngress]; ok {
-		ingressTask, err := p.createDeploySubTask(consts.NodeRoleIngress, deployTask.name, nodes, deployTask.logFilePath, 50)
+		ingressTask, err := p.createDeploySubTask(consts.NodeRoleIngress, deployTask.Name, nodes, deployTask.LogFilePath, 50)
 		if err != nil {
 			err = fmt.Errorf("failed to create deploy ingress sub tasks: %s", err)
 			logger.Error(err)
@@ -100,24 +100,24 @@ func (p *deployProcessor) SplitTask(t Task) error {
 		subTasks = append(subTasks, ingressTask)
 	}
 
-	deployTask.subTasks = subTasks
+	deployTask.SubTasks = subTasks
 	logger.Debugf("Finish to split deploy task: %d sub tasks", len(subTasks))
 
 	return nil
 }
 
 // Verify if the task is valid.
-func (p *deployProcessor) verifyTask(t Task) (*deployTask, error) {
+func (p *deployProcessor) verifyTask(t Task) (*DeployTask, error) {
 	if t == nil {
 		return nil, consts.ErrEmptyTask
 	}
 
-	deployTask, ok := t.(*deployTask)
+	deployTask, ok := t.(*DeployTask)
 	if !ok {
 		return nil, fmt.Errorf("%s: %T", consts.MsgTaskTypeMismatched, t)
 	}
 
-	if len(deployTask.nodeConfigs) == 0 {
+	if len(deployTask.NodeConfigs) == 0 {
 		return nil, fmt.Errorf("nodeConfigs is empty")
 	}
 
@@ -137,7 +137,7 @@ func (p *deployProcessor) groupByRole(cfgs []*pb.NodeDeployConfig) map[consts.No
 	return roles
 }
 
-func (p *deployProcessor) createInitSubTask(t *deployTask, logFileBasePath string, priority int) (Task, error) {
+func (p *deployProcessor) createInitSubTask(t *DeployTask, logFileBasePath string, priority int) (Task, error) {
 	// TODO
 	return nil, nil
 }

--- a/pkg/deploy/task/deploy_task.go
+++ b/pkg/deploy/task/deploy_task.go
@@ -31,10 +31,11 @@ type DeployTaskConfig struct {
 	Priority        int
 }
 
-type deployTask struct {
-	base
-	nodeConfigs   []*pb.NodeDeployConfig
-	clusterConfig *pb.ClusterConfig
+type DeployTask struct {
+	Base
+
+	NodeConfigs   []*pb.NodeDeployConfig
+	ClusterConfig *pb.ClusterConfig
 }
 
 // NewDeployTask returns a deploy task based on the config.
@@ -53,17 +54,17 @@ func NewDeployTask(taskName string, taskConfig *DeployTaskConfig) (Task, error) 
 		return nil, err
 	}
 
-	task := &deployTask{
-		base: base{
-			name:              taskName,
-			taskType:          TaskTypeDeploy,
-			status:            TaskPending,
-			logFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
-			creationTimestamp: time.Now(),
-			priority:          taskConfig.Priority,
+	task := &DeployTask{
+		Base: Base{
+			Name:              taskName,
+			TaskType:          TaskTypeDeploy,
+			Status:            TaskPending,
+			LogFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
+			CreationTimestamp: time.Now(),
+			Priority:          taskConfig.Priority,
 		},
-		nodeConfigs:   taskConfig.NodeConfigs,
-		clusterConfig: taskConfig.ClusterConfig,
+		NodeConfigs:   taskConfig.NodeConfigs,
+		ClusterConfig: taskConfig.ClusterConfig,
 	}
 
 	return task, nil

--- a/pkg/deploy/task/fetch_kube_config_processor.go
+++ b/pkg/deploy/task/fetch_kube_config_processor.go
@@ -44,13 +44,13 @@ func (p *fetchKubeConfigProcessor) SplitTask(t Task) error {
 
 	// split task into an actions
 	act, err := action.NewFetchKubeConfigAction(&action.FetchKubeConfigActionConfig{
-		Node:            kubeCfgTask.node,
-		LogFileBasePath: kubeCfgTask.logFilePath,
+		Node:            kubeCfgTask.Node,
+		LogFileBasePath: kubeCfgTask.LogFilePath,
 	})
 	if err != nil {
 		return err
 	}
-	kubeCfgTask.actions = []action.Action{act}
+	kubeCfgTask.Actions = []action.Action{act}
 
 	logrus.Debugf("Finish to split task")
 	return nil
@@ -67,14 +67,14 @@ func (p *fetchKubeConfigProcessor) ProcessExtraResult(t Task) error {
 	})
 
 	kubeCfgTask := t.(*FetchKubeConfigTask)
-	if len(kubeCfgTask.actions) == 0 {
+	if len(kubeCfgTask.Actions) == 0 {
 		logger.Debug("Task has no action")
 		return nil
 	}
 
-	kubeCfgAction, ok := kubeCfgTask.actions[0].(*action.FetchKubeConfigAction)
+	kubeCfgAction, ok := kubeCfgTask.Actions[0].(*action.FetchKubeConfigAction)
 	if !ok {
-		return fmt.Errorf("%s: %T", consts.MsgActionTypeMismatched, kubeCfgTask.actions[0])
+		return fmt.Errorf("%s: %T", consts.MsgActionTypeMismatched, kubeCfgTask.Actions[0])
 	}
 
 	kubeCfgTask.KubeConfig = kubeCfgAction.KubeConfig
@@ -93,7 +93,7 @@ func (p *fetchKubeConfigProcessor) verifyTask(t Task) error {
 		return fmt.Errorf("%s: %T", consts.MsgTaskTypeMismatched, t)
 	}
 
-	if kubeCfgTask.node == nil {
+	if kubeCfgTask.Node == nil {
 		return fmt.Errorf("node field is nil")
 	}
 

--- a/pkg/deploy/task/fetch_kube_config_processor_test.go
+++ b/pkg/deploy/task/fetch_kube_config_processor_test.go
@@ -33,12 +33,12 @@ func TestVerifyTask(t *testing.T) {
 			want: false,
 		},
 		{
-			task: new(nodeCheckTask),
+			task: new(NodeCheckTask),
 			want: false,
 		},
 		{
 			task: &FetchKubeConfigTask{
-				node: new(pb.Node),
+				Node: new(pb.Node),
 			},
 			want: true,
 		},
@@ -86,7 +86,7 @@ func TestProcessExtraResult(t *testing.T) {
 	assert.NoError(t, err)
 	kubeConfigContent := []byte("test content")
 	kubeconfigAct.(*action.FetchKubeConfigAction).KubeConfig = kubeConfigContent
-	kubeConfigTask.(*FetchKubeConfigTask).actions = []action.Action{kubeconfigAct}
+	kubeConfigTask.(*FetchKubeConfigTask).Actions = []action.Action{kubeconfigAct}
 
 	processor := new(fetchKubeConfigProcessor)
 	err = processor.ProcessExtraResult(kubeConfigTask)

--- a/pkg/deploy/task/fetch_kube_config_task.go
+++ b/pkg/deploy/task/fetch_kube_config_task.go
@@ -29,9 +29,9 @@ type FetchKubeConfigTaskConfig struct {
 }
 
 type FetchKubeConfigTask struct {
-	base
-	node *pb.Node
+	Base
 
+	Node *pb.Node
 	// KubeConfig stores the task result: content of kube config file.
 	KubeConfig []byte
 }
@@ -51,15 +51,15 @@ func NewFetchKubeConfigTask(taskName string, taskConfig *FetchKubeConfigTaskConf
 	}
 
 	task := &FetchKubeConfigTask{
-		base: base{
-			name:              taskName,
-			taskType:          TaskTypeFetchKubeConfig,
-			status:            TaskPending,
-			logFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
-			creationTimestamp: time.Now(),
-			priority:          taskConfig.Priority,
+		Base: Base{
+			Name:              taskName,
+			TaskType:          TaskTypeFetchKubeConfig,
+			Status:            TaskPending,
+			LogFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
+			CreationTimestamp: time.Now(),
+			Priority:          taskConfig.Priority,
 		},
-		node: taskConfig.Node,
+		Node: taskConfig.Node,
 	}
 
 	return task, nil

--- a/pkg/deploy/task/fetch_kube_config_task_test.go
+++ b/pkg/deploy/task/fetch_kube_config_task_test.go
@@ -56,5 +56,5 @@ func TestNewFetchKubeConfigTask(t *testing.T) {
 	assert.IsType(t, &FetchKubeConfigTask{}, aTask)
 	assert.Equal(t, TaskTypeFetchKubeConfig, aTask.GetType())
 	assert.Equal(t, TaskPending, aTask.GetStatus())
-	assert.Equal(t, cfg.Node, aTask.(*FetchKubeConfigTask).node)
+	assert.Equal(t, cfg.Node, aTask.(*FetchKubeConfigTask).Node)
 }

--- a/pkg/deploy/task/node_check_processor.go
+++ b/pkg/deploy/task/node_check_processor.go
@@ -40,15 +40,15 @@ func (p *nodeCheckProcessor) SplitTask(t Task) error {
 
 	logger.Debug("Start to split node check task")
 
-	checkTask := t.(*nodeCheckTask)
+	checkTask := t.(*NodeCheckTask)
 
 	// split task into actions: will create a action for every node, the action type
 	// is NodeCheckAction
-	actions := make([]action.Action, 0, len(checkTask.nodeConfigs))
-	for _, subConfig := range checkTask.nodeConfigs {
+	actions := make([]action.Action, 0, len(checkTask.NodeConfigs))
+	for _, subConfig := range checkTask.NodeConfigs {
 		actionCfg := &action.NodeCheckActionConfig{
 			NodeCheckConfig: subConfig,
-			LogFileBasePath: checkTask.logFilePath,
+			LogFileBasePath: checkTask.LogFilePath,
 		}
 		act, err := action.NewNodeCheckAction(actionCfg)
 		if err != nil {
@@ -56,7 +56,7 @@ func (p *nodeCheckProcessor) SplitTask(t Task) error {
 		}
 		actions = append(actions, act)
 	}
-	checkTask.actions = actions
+	checkTask.Actions = actions
 
 	logrus.Debugf("Finish to split node check task: %d actions", len(actions))
 	return nil
@@ -68,12 +68,12 @@ func (p *nodeCheckProcessor) verifyTask(t Task) error {
 		return consts.ErrEmptyTask
 	}
 
-	nodeCheckTask, ok := t.(*nodeCheckTask)
+	nodeCheckTask, ok := t.(*NodeCheckTask)
 	if !ok {
 		return fmt.Errorf("%s: %T", consts.MsgTaskTypeMismatched, t)
 	}
 
-	if len(nodeCheckTask.nodeConfigs) == 0 {
+	if len(nodeCheckTask.NodeConfigs) == 0 {
 		return fmt.Errorf("nodeConfigs is empty")
 	}
 

--- a/pkg/deploy/task/node_check_task.go
+++ b/pkg/deploy/task/node_check_task.go
@@ -30,9 +30,10 @@ type NodeCheckTaskConfig struct {
 	Priority        int
 }
 
-type nodeCheckTask struct {
-	base
-	nodeConfigs []*pb.NodeCheckConfig
+type NodeCheckTask struct {
+	Base
+
+	NodeConfigs []*pb.NodeCheckConfig
 }
 
 // NewNodeCheckTask returns a node check task based on the config.
@@ -52,16 +53,16 @@ func NewNodeCheckTask(taskName string, taskConfig *NodeCheckTaskConfig) (Task, e
 		return nil, err
 	}
 
-	task := &nodeCheckTask{
-		base: base{
-			name:              taskName,
-			taskType:          TaskTypeNodeCheck,
-			status:            TaskPending,
-			logFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
-			creationTimestamp: time.Now(),
-			priority:          taskConfig.Priority,
+	task := &NodeCheckTask{
+		Base: Base{
+			Name:              taskName,
+			TaskType:          TaskTypeNodeCheck,
+			Status:            TaskPending,
+			LogFilePath:       GenTaskLogFilePath(taskConfig.LogFileBasePath, taskName),
+			CreationTimestamp: time.Now(),
+			Priority:          taskConfig.Priority,
 		},
-		nodeConfigs: taskConfig.NodeConfigs,
+		NodeConfigs: taskConfig.NodeConfigs,
 	}
 
 	return task, nil

--- a/pkg/deploy/task/task.go
+++ b/pkg/deploy/task/task.go
@@ -70,70 +70,70 @@ const (
 	TaskFailed    Status = "Failed"
 )
 
-type base struct {
-	name              string
-	taskType          Type
-	actions           []action.Action
-	status            Status
-	err               *pb.Error
-	logFileBasePath   string
-	logFilePath       string
-	creationTimestamp time.Time
-	subTasks          []Task
-	priority          int
-	parent            string
+type Base struct {
+	Name              string
+	TaskType          Type
+	Actions           []action.Action
+	Status            Status
+	Err               *pb.Error
+	LogFileBasePath   string
+	LogFilePath       string
+	CreationTimestamp time.Time
+	SubTasks          []Task
+	Priority          int
+	Parent            string
 }
 
-func (b *base) GetName() string {
-	return b.name
+func (b *Base) GetName() string {
+	return b.Name
 }
 
-func (b *base) GetType() Type {
-	return b.taskType
+func (b *Base) GetType() Type {
+	return b.TaskType
 }
 
-func (b *base) GetStatus() Status {
-	return b.status
+func (b *Base) GetStatus() Status {
+	return b.Status
 }
 
-func (b *base) SetStatus(status Status) {
-	b.status = status
+func (b *Base) SetStatus(status Status) {
+	b.Status = status
 }
 
-func (b *base) GetErr() *pb.Error {
-	return b.err
+func (b *Base) GetErr() *pb.Error {
+	return b.Err
 }
 
-func (b *base) SetErr(err *pb.Error) {
-	b.err = err
+func (b *Base) SetErr(err *pb.Error) {
+	b.Err = err
 }
 
-func (b *base) GetLogFilePath() string {
-	return b.logFilePath
+func (b *Base) GetLogFilePath() string {
+	return b.LogFilePath
 }
 
-func (b *base) SetLogFilePath(path string) {
-	b.logFilePath = path
+func (b *Base) SetLogFilePath(path string) {
+	b.LogFilePath = path
 }
 
-func (b *base) GetActions() []action.Action {
-	return b.actions
+func (b *Base) GetActions() []action.Action {
+	return b.Actions
 }
 
-func (b *base) GetCreationTimestamp() time.Time {
-	return b.creationTimestamp
+func (b *Base) GetCreationTimestamp() time.Time {
+	return b.CreationTimestamp
 }
 
-func (b *base) GetSubTasks() []Task {
-	return b.subTasks
+func (b *Base) GetSubTasks() []Task {
+	return b.SubTasks
 }
 
-func (b *base) GetPriority() int {
-	return b.priority
+func (b *Base) GetPriority() int {
+	return b.Priority
 }
 
-func (b *base) GetParent() string {
-	return b.parent
+func (b *Base) GetParent() string {
+	return b.Parent
 }
 
 // GenTaskLogFilePath is a helper to return the log file path based on base path and task name


### PR DESCRIPTION
Why we do that?
1. Clients, like api controller, would like to get the detail information about tasks/actions.
2. In the near future, tasks/actions would be serialized which will require they are public.