### PR TITLE
build(makefile): truns off verbose info for "test" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ service_doc:
 .PHONY: test
 test:
 	mkdir -p .test-result
-	go test -v -cover -coverprofile cover.out -outputdir .test-result ./...
+	go test -cover -coverprofile cover.out -outputdir .test-result ./...
 	go tool cover -html=.test-result/cover.out -o .test-result/coverage.html
 
 .PHONY: build_service_local


### PR DESCRIPTION
Why we do that?
1.Print out simple information so that we can find the test failure easily.
2.Failed tests will still print out verbose info.