### PR TITLE
refactor(deploy/actions): remove the logic to set action's Status & Err from Executor.Execute() method

### DIFF
--- a/pkg/deploy/action/fetch_kube_config_executor.go
+++ b/pkg/deploy/action/fetch_kube_config_executor.go
@@ -15,20 +15,19 @@
 package action
 
 import (
-	"fmt"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
+	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
 type fetchKubeConfigExecutor struct {
 }
 
-func (a *fetchKubeConfigExecutor) Execute(act Action) error {
+func (a *fetchKubeConfigExecutor) Execute(act Action) *pb.Error {
 	kubeCfgAction, ok := act.(*FetchKubeConfigAction)
 	if !ok {
-		return fmt.Errorf("the action type is not match: should be fetch kube config action, but is %T", act)
+		return errOfTypeMismatched(new(FetchKubeConfigAction), act)
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
@@ -40,7 +39,6 @@ func (a *fetchKubeConfigExecutor) Execute(act Action) error {
 	// TODO: ssh to fetch kube config file from kubeCfgAction.node
 
 	// Update action
-	kubeCfgAction.Status = ActionDone
 	kubeCfgAction.KubeConfig = []byte("todo: the content of kube config file")
 
 	logger.Debug("Finsih to execute action")

--- a/pkg/deploy/action/join_master_executor.go
+++ b/pkg/deploy/action/join_master_executor.go
@@ -15,8 +15,6 @@
 package action
 
 import (
-	"fmt"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
@@ -27,10 +25,10 @@ import (
 type joinMasterExecutor struct {
 }
 
-func (a *joinMasterExecutor) Execute(act Action) error {
+func (a *joinMasterExecutor) Execute(act Action) *pb.Error {
 	action, ok := act.(*JoinMasterTask)
 	if !ok {
-		return fmt.Errorf("the action type is not match: should be join master action, but is %T", act)
+		return errOfTypeMismatched(new(JoinMasterTask), act)
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
@@ -48,14 +46,15 @@ func (a *joinMasterExecutor) Execute(act Action) error {
 
 	op, err := master.NewJoinMasterOperation(config)
 	if err != nil {
-		return fmt.Errorf("failed to get etcd operation, error: %v", err)
+		return &pb.Error{
+			Reason: "failed to get etcd operation",
+			Detail: err.Error(),
+		}
 	}
 
-	action.Status = ActionDone
 	if err := op.Do(); err != nil {
-		action.Status = ActionFailed
-		action.Err = &pb.Error{
-			Reason:     err.Error(),
+		return &pb.Error{
+			Reason:     "failed to get etcd operation",
 			Detail:     err.Error(),
 			FixMethods: "",
 		}

--- a/pkg/deploy/action/node_check_executor.go
+++ b/pkg/deploy/action/node_check_executor.go
@@ -285,10 +285,10 @@ func CheckSysPrefExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
-func (a *nodeCheckExecutor) Execute(act Action) error {
+func (a *nodeCheckExecutor) Execute(act Action) *pb.Error {
 	nodeCheckAction, ok := act.(*NodeCheckAction)
 	if !ok {
-		return fmt.Errorf("the action type is not match: should be node check action, but is %T", act)
+		return errOfTypeMismatched(new(NodeCheckAction), act)
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
@@ -310,7 +310,25 @@ func (a *nodeCheckExecutor) Execute(act Action) error {
 	go CheckSysPrefExecutor(nodeCheckAction, &wg)
 	wg.Wait()
 
-	nodeCheckAction.Status = ActionDone
+	// If any of them was failed, we should return an error
+	failedItems := getFailedCheckItems(nodeCheckAction)
+	if len(failedItems) > 0 {
+		return &pb.Error{
+			Reason: fmt.Sprintf("%d check item(s) failed", len(failedItems)),
+			Detail: fmt.Sprintf("failed check item list: %v", failedItems),
+		}
+	}
+
 	logger.Debug("Finish to execute node check action")
 	return nil
+}
+
+func getFailedCheckItems(checkAction *NodeCheckAction) []string {
+	var failedItemName []string
+	for _, item := range checkAction.CheckItems {
+		if item.Status != nodeInitItemDone {
+			failedItemName = append(failedItemName, item.Name)
+		}
+	}
+	return failedItemName
 }

--- a/pkg/deploy/action/node_check_executor.go
+++ b/pkg/deploy/action/node_check_executor.go
@@ -310,7 +310,7 @@ func (a *nodeCheckExecutor) Execute(act Action) *pb.Error {
 	go CheckSysPrefExecutor(nodeCheckAction, &wg)
 	wg.Wait()
 
-	// If any of them was failed, we should return an error
+	// If any of check item was failed, we should return an error
 	failedItems := getFailedCheckItems(nodeCheckAction)
 	if len(failedItems) > 0 {
 		return &pb.Error{
@@ -326,7 +326,7 @@ func (a *nodeCheckExecutor) Execute(act Action) *pb.Error {
 func getFailedCheckItems(checkAction *NodeCheckAction) []string {
 	var failedItemName []string
 	for _, item := range checkAction.CheckItems {
-		if item.Status != nodeInitItemDone {
+		if item.Status != ItemActionDone {
 			failedItemName = append(failedItemName, item.Name)
 		}
 	}

--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -128,7 +128,7 @@ func (a *nodeInitExecutor) Execute(act Action) *pb.Error {
 
 	wg.Wait()
 
-	// If any of them was failed, we should return an error
+	// If any of init item was failed, we should return an error
 	failedItems := getFailedInitItems(nodeInitAction)
 	if len(failedItems) > 0 {
 		return &pb.Error{

--- a/pkg/deploy/consts/msg.go
+++ b/pkg/deploy/consts/msg.go
@@ -36,6 +36,7 @@ const (
 	MsgActionExecutorCreationFailed string = "failed to create action executor"
 	MsgActionExecutionFailed        string = "failed to execute aciton"
 	MsgActionTypeMismatched         string = "action type mismatched"
+	MsgActionTypeMismatchedDetail   string = "the action type is not match: should be %T, but is %T"
 )
 
 var (


### PR DESCRIPTION

1.The responsibility to set action's Status & Err is now owned by action.ExecuteAction() method.
2.Each concrete executor just need to returen an *pb.Error for caller in its Execute() method..