### PR TITLE
refactor(deploy/Executor): changes the way to add new action support via registry

### DIFF
--- a/pkg/deploy/action/action.go
+++ b/pkg/deploy/action/action.go
@@ -26,19 +26,6 @@ import (
 // Type represents the type of an action
 type Type string
 
-const (
-	ActionTypeNodeCheck         Type = "NodeCheck"
-	ActionTypeNodeInit          Type = "NodeInit"
-	ActionTypeDeployEtcd        Type = "DeployEtcd"
-	ActionTypeDeployMaster      Type = "DeployMaster"
-	ActionTypeInitMaster        Type = "InitMaster"
-	ActionTypeJoinMaster        Type = "JoinMaster"
-	ActionTypeDeployWorker      Type = "DeployWorker"
-	ActionTypeDeployIngress     Type = "DeployIngress"
-	ActionTypeFetchKubeConfig   Type = "FetchKubeConfig"
-	ActionTypeConnectivityCheck Type = "ConnectivityCheck"
-)
-
 // Status represents the status of an action
 type Status string
 

--- a/pkg/deploy/action/connectivity_check_action.go
+++ b/pkg/deploy/action/connectivity_check_action.go
@@ -27,6 +27,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeConnectivityCheck Type = "ConnectivityCheck"
+
 // ConnectivityCheckItem an item representing one check item of checking wheter a node can connect to another by the protocol and port.
 type ConnectivityCheckItem struct {
 	Protocol    consts.Protocol
@@ -84,6 +86,10 @@ func NewConnectivityCheckAction(cfg *ConnectivityCheckActionConfig) (Action, err
 		DestinationNode: cfg.DestinationNode,
 		CheckItems:      cfg.ConnectivityCheckItems,
 	}, nil
+}
+
+func init() {
+	RegisterExecutor(ActionTypeConnectivityCheck, new(connectivityCheckExecutor))
 }
 
 type connectivityCheckExecutor struct{}

--- a/pkg/deploy/action/deploy_etcd_action.go
+++ b/pkg/deploy/action/deploy_etcd_action.go
@@ -25,6 +25,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeDeployEtcd Type = "DeployEtcd"
+
 // DeployEtcdActionConfig represents the config for a ectd deploy in a node
 type DeployEtcdActionConfig struct {
 	CaCrt           *x509.Certificate

--- a/pkg/deploy/action/deploy_etcd_executor.go
+++ b/pkg/deploy/action/deploy_etcd_executor.go
@@ -22,6 +22,10 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+func init() {
+	RegisterExecutor(ActionTypeDeployEtcd, new(deployEtcdExecutor))
+}
+
 type deployEtcdExecutor struct {
 }
 

--- a/pkg/deploy/action/deploy_worker_action.go
+++ b/pkg/deploy/action/deploy_worker_action.go
@@ -21,6 +21,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeDeployWorker Type = "DeployWorker"
+
 type DeployWorkerActionConfig struct {
 	Node            *pb.NodeDeployConfig
 	ClusterConfig   *pb.ClusterConfig

--- a/pkg/deploy/action/deploy_worker_executor.go
+++ b/pkg/deploy/action/deploy_worker_executor.go
@@ -25,6 +25,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+func init() {
+	RegisterExecutor(ActionTypeDeployWorker, new(deployWorkerExecutor))
+}
+
 type deployWorkerExecutor struct {
 	logger  *logrus.Entry
 	machine *deployMachine.Machine

--- a/pkg/deploy/action/executor.go
+++ b/pkg/deploy/action/executor.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
@@ -28,29 +30,35 @@ type Executor interface {
 	Execute(act Action) *pb.Error
 }
 
+var _executorRegistry map[Type]Executor
+
+// RegisterExecutor is to register an Executor for an action type
+func RegisterExecutor(actionType Type, exec Executor) error {
+	if _executorRegistry == nil {
+		_executorRegistry = make(map[Type]Executor)
+	}
+	if exec == nil {
+		err := fmt.Errorf("the Executor to be registered is nil")
+		logrus.Error(err)
+		return err
+	}
+	if _, ok := _executorRegistry[actionType]; ok {
+		err := fmt.Errorf("the Executor for type %v has already been registered", actionType)
+		logrus.Error(err)
+		return err
+	}
+	_executorRegistry[actionType] = exec
+	return nil
+}
+
 // NewExecutor is a simple factory method to return an action executor based on action type.
 func NewExecutor(actionType Type) (Executor, error) {
-	var executor Executor
-	switch actionType {
-	case ActionTypeNodeCheck:
-		executor = &nodeCheckExecutor{}
-	case ActionTypeNodeInit:
-		executor = &nodeInitExecutor{}
-	case ActionTypeDeployEtcd:
-		executor = &deployEtcdExecutor{}
-	case ActionTypeDeployWorker:
-		executor = &deployWorkerExecutor{}
-	case ActionTypeConnectivityCheck:
-		executor = &connectivityCheckExecutor{}
-	case ActionTypeInitMaster:
-		executor = &initMasterExecutor{}
-	case ActionTypeJoinMaster:
-		executor = &joinMasterExecutor{}
-	default:
+	exec, ok := _executorRegistry[actionType]
+	if !ok {
 		return nil, fmt.Errorf("%s: %s", consts.MsgActionTypeUnsupported, actionType)
 	}
 
-	return executor, nil
+	return exec, nil
 }
 
 // ExecuteAction creates and run the executor for an action,

--- a/pkg/deploy/action/executor_test.go
+++ b/pkg/deploy/action/executor_test.go
@@ -1,0 +1,108 @@
+// Copyright 2019 Shanghai JingDuo Information Technology co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
+)
+
+const ActionTypeTestExecutorMockup Type = "ActionTypeMockupForExecutorTest"
+
+type actionMockupForExecutorTest struct {
+	Base
+
+	goodResult bool
+}
+
+type executorMockupForExecutorTest struct{}
+
+func (e *executorMockupForExecutorTest) Execute(act Action) *pb.Error {
+	mockupAct, ok := act.(*actionMockupForExecutorTest)
+	if !ok {
+		return new(pb.Error)
+	}
+	if !mockupAct.goodResult {
+		return new(pb.Error)
+	}
+	return nil
+}
+
+func TestRegisterExecutor(t *testing.T) {
+	err := RegisterExecutor(ActionTypeTestExecutorMockup, new(executorMockupForExecutorTest))
+	assert.NoError(t, err)
+
+	exec, err := NewExecutor(ActionTypeTestExecutorMockup)
+	assert.NoError(t, err)
+	assert.NotNil(t, exec)
+	assert.IsType(t, new(executorMockupForExecutorTest), exec)
+
+	err = RegisterExecutor(ActionTypeTestExecutorMockup, new(executorMockupForExecutorTest))
+	assert.Error(t, err)
+
+	// cleanup
+	_executorRegistry = nil
+}
+
+func TestExecuteAction(t *testing.T) {
+	err := RegisterExecutor(ActionTypeTestExecutorMockup, new(executorMockupForExecutorTest))
+	assert.NoError(t, err)
+
+	input := []struct {
+		action     Action
+		wantStatus Status
+		wantErr    bool
+	}{
+		{
+			action: &actionMockupForExecutorTest{
+				Base: Base{
+					Name:       "action1",
+					ActionType: ActionTypeTestExecutorMockup,
+				},
+				goodResult: true,
+			},
+			wantStatus: ActionDone,
+			wantErr:    false,
+		},
+		{
+			action: &actionMockupForExecutorTest{
+				Base: Base{
+					Name:       "action2",
+					ActionType: ActionTypeTestExecutorMockup,
+				},
+				goodResult: false,
+			},
+			wantStatus: ActionFailed,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range input {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		ExecuteAction(tt.action, &wg)
+		wg.Wait()
+
+		assert.Equal(t, tt.wantStatus, tt.action.GetStatus())
+		assert.Equal(t, tt.wantErr, tt.action.GetErr() != nil)
+	}
+
+	// cleanup
+	_executorRegistry = nil
+}

--- a/pkg/deploy/action/fetch_kube_config_action.go
+++ b/pkg/deploy/action/fetch_kube_config_action.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeFetchKubeConfig Type = "FetchKubeConfig"
+
 // FetchKubeConfigActionConfig represents the config for a action to fetch the kube config
 type FetchKubeConfigActionConfig struct {
 	Node            *pb.Node

--- a/pkg/deploy/action/fetch_kube_config_executor.go
+++ b/pkg/deploy/action/fetch_kube_config_executor.go
@@ -21,6 +21,10 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+func init() {
+	RegisterExecutor(ActionTypeFetchKubeConfig, new(fetchKubeConfigExecutor))
+}
+
 type fetchKubeConfigExecutor struct {
 }
 

--- a/pkg/deploy/action/init_master_action.go
+++ b/pkg/deploy/action/init_master_action.go
@@ -21,6 +21,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeInitMaster Type = "InitMaster"
+
 type InitMasterActionConfig struct {
 	Node            *pb.Node
 	MasterNodes     []*pb.Node

--- a/pkg/deploy/action/init_master_executor.go
+++ b/pkg/deploy/action/init_master_executor.go
@@ -22,6 +22,10 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+func init() {
+	RegisterExecutor(ActionTypeInitMaster, new(initMasterExecutor))
+}
+
 type initMasterExecutor struct {
 }
 

--- a/pkg/deploy/action/join_master_action.go
+++ b/pkg/deploy/action/join_master_action.go
@@ -21,6 +21,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeJoinMaster Type = "JoinMaster"
+
 type joinMasterStatus string
 
 type JoinMasterActionConfig struct {

--- a/pkg/deploy/action/join_master_executor.go
+++ b/pkg/deploy/action/join_master_executor.go
@@ -22,6 +22,10 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+func init() {
+	RegisterExecutor(ActionTypeJoinMaster, new(joinMasterExecutor))
+}
+
 type joinMasterExecutor struct {
 }
 

--- a/pkg/deploy/action/node_check_action.go
+++ b/pkg/deploy/action/node_check_action.go
@@ -24,6 +24,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeNodeCheck Type = "NodeCheck"
+
 // NodeCheckActionConfig represents the config for a node check action
 type NodeCheckActionConfig struct {
 	NodeCheckConfig *pb.NodeCheckConfig

--- a/pkg/deploy/action/node_check_executor.go
+++ b/pkg/deploy/action/node_check_executor.go
@@ -51,6 +51,10 @@ const (
 
 var systemDistributions = [3]string{check.DistributionCentos, check.DistributionUbuntu, check.DistributionRHEL}
 
+func init() {
+	RegisterExecutor(ActionTypeNodeCheck, new(nodeCheckExecutor))
+}
+
 type nodeCheckExecutor struct {
 }
 

--- a/pkg/deploy/action/node_init_action.go
+++ b/pkg/deploy/action/node_init_action.go
@@ -24,6 +24,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const ActionTypeNodeInit Type = "NodeInit"
+
 const (
 	nodeInitItemPending = "pending"
 	nodeInitItemDoing   = "doing"

--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -25,6 +25,10 @@ import (
 	"sync"
 )
 
+func init() {
+	RegisterExecutor(ActionTypeNodeInit, new(nodeInitExecutor))
+}
+
 type nodeInitExecutor struct{}
 
 // due to items, ItemInitScripts exec remote scripts and return std, report, error


### PR DESCRIPTION

 Modification:
 1.Adds a registry for Executor
 2.Moves the action type definiton to each action file
 3.Automatically registers each action Executor var init() function
 4.Adds unit test for Executor

 Why we do these changes:
 1.Don't need to change the common files each time we add a new action
 2.Make the codes testable.