### PR TITLE
refactor(deploy/Processor): changes the way to add new task support via registry

### DIFF
--- a/pkg/deploy/consts/msg.go
+++ b/pkg/deploy/consts/msg.go
@@ -24,7 +24,7 @@ const (
 	MsgUnknownFixMethod string = "unknown"
 
 	// Task related messages
-	MsgTaskTypeUnsupported         string = "unsupported action type"
+	MsgTaskTypeUnsupported         string = "unsupported task type"
 	MsgTaskSplitFailed             string = "failed to split task"
 	MsgTaskTypeMismatched          string = "task type mismatched"
 	MsgEmptyTask                   string = "empty task"

--- a/pkg/deploy/task/check_network_requirements.go
+++ b/pkg/deploy/task/check_network_requirements.go
@@ -24,6 +24,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeCheckNetworkRequirements Type = "CheckNetworkRequirements"
+
 // CheckNetworkRequirementsTaskConfig configuration to create a CheckNetworkRequirements task.
 type CheckNetworkRequirementsTaskConfig struct {
 	Nodes           []*pb.Node
@@ -58,6 +60,10 @@ func NewCheckNetworkRequirementsTask(
 		Nodes:          config.Nodes,
 		NetworkOptions: config.NetworkOptions,
 	}, nil
+}
+
+func init() {
+	RegisterProcessor(TaskTypeCheckNetworkRequirements, new(checkNetworkRequirementsProcessor))
 }
 
 type checkNetworkRequirementsProcessor struct{}

--- a/pkg/deploy/task/deploy_etcd_processor.go
+++ b/pkg/deploy/task/deploy_etcd_processor.go
@@ -24,6 +24,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeDeployEtcd, new(deployEtcdProcessor))
+}
+
 // deployEtcdProcessor implements the specific logic to deploy etcd
 type deployEtcdProcessor struct {
 }

--- a/pkg/deploy/task/deploy_etcd_task.go
+++ b/pkg/deploy/task/deploy_etcd_task.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeDeployEtcd Type = "DeployEtcd"
+
 // DeployEtcdTaskConfig represents the config for a deploy etcd task.
 type DeployEtcdTaskConfig struct {
 	Nodes           []*pb.Node

--- a/pkg/deploy/task/deploy_master_processor.go
+++ b/pkg/deploy/task/deploy_master_processor.go
@@ -22,6 +22,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeDeployMaster, new(deployMasterProcessor))
+}
+
 // deployMasterProcessor implements the specific logic to deploy master
 type deployMasterProcessor struct {
 }

--- a/pkg/deploy/task/deploy_master_task.go
+++ b/pkg/deploy/task/deploy_master_task.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeDeployMaster Type = "DeployMaster"
+
 // DeploymasterTaskConfig represents the config for a deploy master task.
 type DeployMasterTaskConfig struct {
 	etcdNodes       []*pb.Node

--- a/pkg/deploy/task/deploy_processor.go
+++ b/pkg/deploy/task/deploy_processor.go
@@ -23,6 +23,10 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeDeploy, new(deployProcessor))
+}
+
 // deployProcessor implements the specific logic for the deploy task.
 type deployProcessor struct {
 }

--- a/pkg/deploy/task/deploy_task.go
+++ b/pkg/deploy/task/deploy_task.go
@@ -27,6 +27,8 @@ import (
 type Operation string
 type Priority int
 
+const TaskTypeDeploy Type = "Deploy"
+
 const (
 	initOperation   Operation = "initialization"
 	deployOperation Operation = "deployment"

--- a/pkg/deploy/task/deploy_worker_processor.go
+++ b/pkg/deploy/task/deploy_worker_processor.go
@@ -23,6 +23,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeDeployWorker, new(DeployWorkerProcessor))
+}
+
 type DeployWorkerProcessor struct {
 }
 

--- a/pkg/deploy/task/deploy_worker_task.go
+++ b/pkg/deploy/task/deploy_worker_task.go
@@ -21,6 +21,8 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeDeployWorker Type = "DeployWorker"
+
 type DeployWorkerTaskConfig struct {
 	Nodes           []*protos.NodeDeployConfig
 	ClusterConfig   *protos.ClusterConfig

--- a/pkg/deploy/task/fetch_kube_config_processor.go
+++ b/pkg/deploy/task/fetch_kube_config_processor.go
@@ -23,6 +23,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeFetchKubeConfig, new(fetchKubeConfigProcessor))
+}
+
 // fetchKubeConfigProcessor implements the specific logic for the fetch-kube-config task.
 type fetchKubeConfigProcessor struct {
 }

--- a/pkg/deploy/task/fetch_kube_config_task.go
+++ b/pkg/deploy/task/fetch_kube_config_task.go
@@ -21,6 +21,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeFetchKubeConfig Type = "FetchKubeConfig"
+
 // FetchKubeConfigTaskConfig represents the config for a fetch-kube-config task.
 type FetchKubeConfigTaskConfig struct {
 	Node            *pb.Node

--- a/pkg/deploy/task/init_master_processor.go
+++ b/pkg/deploy/task/init_master_processor.go
@@ -22,6 +22,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeInitMaster, new(initMasterProcessor))
+}
+
 type initMasterProcessor struct {
 }
 

--- a/pkg/deploy/task/init_master_task.go
+++ b/pkg/deploy/task/init_master_task.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeInitMaster Type = "InitMaster"
+
 const (
 	InitMasterOperation Operation = "init"
 	InitMasterPriority  Priority  = 10

--- a/pkg/deploy/task/join_master_processor.go
+++ b/pkg/deploy/task/join_master_processor.go
@@ -22,6 +22,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeJoinMaster, new(joinMasterProcessor))
+}
+
 type joinMasterProcessor struct {
 }
 

--- a/pkg/deploy/task/join_master_task.go
+++ b/pkg/deploy/task/join_master_task.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeJoinMaster Type = "JoinMaster"
+
 const (
 	JointMasterOperation Operation = "join"
 	JoinMasterPriority   Priority  = 20

--- a/pkg/deploy/task/node_check_processor.go
+++ b/pkg/deploy/task/node_check_processor.go
@@ -25,6 +25,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeNodeCheck, new(nodeCheckProcessor))
+}
+
 // nodeCheckProcessor implements the specific logic for the node check task.
 type nodeCheckProcessor struct {
 }

--- a/pkg/deploy/task/node_check_task.go
+++ b/pkg/deploy/task/node_check_task.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeNodeCheck Type = "NodeCheck"
+
 // NodeCheckTaskConfig represents the config for a node check task.
 type NodeCheckTaskConfig struct {
 	NodeConfigs     []*pb.NodeCheckConfig

--- a/pkg/deploy/task/node_init_processor.go
+++ b/pkg/deploy/task/node_init_processor.go
@@ -23,6 +23,10 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 )
 
+func init() {
+	RegisterProcessor(TaskTypeNodeInit, new(nodeInitProcessor))
+}
+
 // nodeInitProcessor implements the specific logic to init nodes
 type nodeInitProcessor struct{}
 

--- a/pkg/deploy/task/node_init_task.go
+++ b/pkg/deploy/task/node_init_task.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
 
+const TaskTypeNodeInit Type = "NodeInit"
+
 // NodeInitTaskConfig represents the config for a node init task
 type NodeInitTaskConfig struct {
 	Nodes           []*pb.Node

--- a/pkg/deploy/task/processor_test.go
+++ b/pkg/deploy/task/processor_test.go
@@ -1,0 +1,181 @@
+// Copyright 2019 Shanghai JingDuo Information Technology co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kpaas-io/kpaas/pkg/deploy/action"
+	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
+)
+
+// Mockup an action and excutor
+const ActionTypeTestProcessorMockup action.Type = "ActionTypeMockupForProcessorTest"
+
+type actionMockupForProcessorTest struct {
+	action.Base
+}
+type executorMockupForProcessorTest struct{}
+
+func (e *executorMockupForProcessorTest) Execute(act action.Action) *pb.Error {
+	_, ok := act.(*actionMockupForProcessorTest)
+	if !ok {
+		return new(pb.Error)
+	}
+	// just for testing: do nothing.
+	return nil
+}
+
+// Mockup three task types and processors
+const TaskTypeTestProcessorMockup1 Type = "TaskTypeMockupForProcessorTest1"
+const TaskTypeTestProcessorMockup2 Type = "TaskTypeMockupForProcessorTest2"
+const TaskTypeTestProcessorMockup3 Type = "TaskTypeMockupForProcessorTest3"
+
+type taskMockupForProcessorTest1 struct {
+	Base
+}
+type taskMockupForProcessorTest2 struct {
+	Base
+}
+type taskMockupForProcessorTest3 struct {
+	Base
+}
+
+type processorMockupForProcessorTest1 struct{}
+type processorMockupForProcessorTest2 struct{}
+type processorMockupForProcessorTest3 struct{}
+
+func (e *processorMockupForProcessorTest1) SplitTask(t Task) error {
+	task1, ok := t.(*taskMockupForProcessorTest1)
+	if !ok {
+		return fmt.Errorf("mismatched task type")
+	}
+	// Split it into two mockup sub tasks
+	task2 := &taskMockupForProcessorTest2{
+		Base: Base{
+			Name:     "task2",
+			TaskType: TaskTypeTestProcessorMockup2,
+			Status:   TaskPending,
+			Parent:   t.GetName(),
+		},
+	}
+	task3 := &taskMockupForProcessorTest3{
+		Base: Base{
+			Name:     "task3",
+			TaskType: TaskTypeTestProcessorMockup3,
+			Status:   TaskPending,
+			Parent:   t.GetName(),
+		},
+	}
+
+	task1.SubTasks = []Task{task2, task3}
+
+	return nil
+}
+
+func (e *processorMockupForProcessorTest2) SplitTask(t Task) error {
+	tsk, ok := t.(*taskMockupForProcessorTest2)
+	if !ok {
+		return fmt.Errorf("mismatched task type")
+	}
+
+	// Split it into one mockup action
+	act1 := &actionMockupForProcessorTest{
+		Base: action.Base{
+			Name:       "action1",
+			ActionType: ActionTypeTestProcessorMockup,
+			Status:     action.ActionPending,
+		},
+	}
+	tsk.Actions = []action.Action{act1}
+	return nil
+}
+
+func (e *processorMockupForProcessorTest3) SplitTask(t Task) error {
+	tsk, ok := t.(*taskMockupForProcessorTest3)
+	if !ok {
+		return fmt.Errorf("mismatched task type")
+	}
+
+	// Split it into one mockup action
+	act2 := &actionMockupForProcessorTest{
+		Base: action.Base{
+			Name:       "action2",
+			ActionType: ActionTypeTestProcessorMockup,
+			Status:     action.ActionPending,
+		},
+	}
+	tsk.Actions = []action.Action{act2}
+	return nil
+}
+
+func TestRegisterProcessor(t *testing.T) {
+	err := RegisterProcessor(TaskTypeTestProcessorMockup1, new(processorMockupForProcessorTest1))
+	assert.NoError(t, err)
+
+	proc, err := NewProcessor(TaskTypeTestProcessorMockup1)
+	assert.NoError(t, err)
+	assert.NotNil(t, proc)
+	assert.IsType(t, new(processorMockupForProcessorTest1), proc)
+
+	err = RegisterProcessor(TaskTypeTestProcessorMockup1, new(processorMockupForProcessorTest1))
+	assert.Error(t, err)
+
+	// cleanup
+	_processRegistry = nil
+}
+
+func TestExecuteTask(t *testing.T) {
+	err := action.RegisterExecutor(ActionTypeTestProcessorMockup, new(executorMockupForProcessorTest))
+	assert.NoError(t, err)
+
+	err = RegisterProcessor(TaskTypeTestProcessorMockup1, new(processorMockupForProcessorTest1))
+	assert.NoError(t, err)
+	err = RegisterProcessor(TaskTypeTestProcessorMockup2, new(processorMockupForProcessorTest2))
+	assert.NoError(t, err)
+	err = RegisterProcessor(TaskTypeTestProcessorMockup3, new(processorMockupForProcessorTest3))
+	assert.NoError(t, err)
+
+	task1 := &taskMockupForProcessorTest1{
+		Base: Base{
+			Name:     "task1",
+			TaskType: TaskTypeTestProcessorMockup1,
+			Status:   TaskPending,
+		},
+	}
+
+	err = ExecuteTask(task1)
+	assert.NoError(t, err)
+	assert.Equal(t, TaskDone, task1.GetStatus())
+	assert.Nil(t, task1.GetErr())
+	assert.Equal(t, 2, len(task1.GetSubTasks()))
+	assert.Equal(t, 0, len(task1.GetActions()))
+	for _, subTask := range task1.GetSubTasks() {
+		assert.Equal(t, TaskDone, subTask.GetStatus())
+		assert.Nil(t, subTask.GetErr())
+		assert.Equal(t, 0, len(subTask.GetSubTasks()))
+		assert.Equal(t, 1, len(subTask.GetActions()))
+		for _, act := range subTask.GetActions() {
+			assert.Equal(t, action.ActionDone, act.GetStatus())
+			assert.Nil(t, act.GetErr())
+		}
+	}
+
+	// cleanup
+	_processRegistry = nil
+}

--- a/pkg/deploy/task/task.go
+++ b/pkg/deploy/task/task.go
@@ -46,20 +46,6 @@ type Task interface {
 // Type represents the type of a task
 type Type string
 
-const (
-	TaskTypeNodeCheck                Type = "NodeCheck"
-	TaskTypeNodeInit                 Type = "NodeInit"
-	TaskTypeDeploy                   Type = "Deploy"
-	TaskTypeDeployEtcd               Type = "DeployEtcd"
-	TaskTypeDeployMaster             Type = "DeployMaster"
-	TaskTypeInitMaster               Type = "InitMaster"
-	TaskTypeJoinMaster               Type = "JoinMaster"
-	TaskTypeDeployWorker             Type = "DeployWorker"
-	TaskTypeDeployIngress            Type = "DeployIngess"
-	TaskTypeFetchKubeConfig          Type = "FetchKubeConfig"
-	TaskTypeCheckNetworkRequirements Type = "CheckNetworkRequirements"
-)
-
 // Status represents the status of a task
 type Status string
 


### PR DESCRIPTION

Modification:
1.Add a registry for Processor
2.Move the task type definiton to each task file
3.Automatically registers each task processor var init() function
4.Adds unit test for Processor

Why we do these changes:
1.Don't need to change the common files each time we add a new task
2.Make the codes testable.