### PR TITLE
feature(deploy/action) write execute log in executor and add execute log format writter in command package #OONE-106

### DIFF
--- a/pkg/deploy/action/action.go
+++ b/pkg/deploy/action/action.go
@@ -16,6 +16,7 @@ package action
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 	"time"
 
@@ -49,6 +50,8 @@ type Action interface {
 	SetLogFilePath(string)
 	GetCreationTimestamp() time.Time
 	GetNode() *pb.Node
+	GetExecuteLogBuffer() io.ReadWriter
+	SetExecuteLogBuffer(io.ReadWriter)
 }
 
 // Base is the basic metadata of an action
@@ -60,6 +63,7 @@ type Base struct {
 	LogFilePath       string
 	CreationTimestamp time.Time
 	Node              *pb.Node
+	ExecuteLogBuffer  io.ReadWriter
 }
 
 func (b *Base) GetName() string {
@@ -100,6 +104,14 @@ func (b *Base) GetCreationTimestamp() time.Time {
 
 func (b *Base) GetNode() *pb.Node {
 	return b.Node
+}
+
+func (b *Base) GetExecuteLogBuffer() io.ReadWriter {
+	return b.ExecuteLogBuffer
+}
+
+func (b *Base) SetExecuteLogBuffer(buf io.ReadWriter) {
+	b.ExecuteLogBuffer = buf
 }
 
 // GenActionLogFilePath is a helper to return a file path based on the base path and aciton name

--- a/pkg/deploy/action/connectivity_check_action.go
+++ b/pkg/deploy/action/connectivity_check_action.go
@@ -15,19 +15,16 @@
 package action
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/kpaas-io/kpaas/pkg/deploy/command"
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"
 	"github.com/kpaas-io/kpaas/pkg/deploy/machine"
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
-	"github.com/kpaas-io/kpaas/pkg/deploy/utils"
 )
 
 const ActionTypeConnectivityCheck Type = "ConnectivityCheck"
@@ -117,21 +114,6 @@ func (e *connectivityCheckExecutor) Execute(act Action) *pb.Error {
 		consts.LogFieldAction: act.GetName(),
 	})
 
-	buf := &bytes.Buffer{}
-	defer func() {
-		executeLogWriter, err := os.OpenFile(
-			connectivityCheckAction.LogFilePath, os.O_CREATE|os.O_RDWR, 0644)
-		if err != nil {
-			logger.Errorf("failed to open execute log file %s, error %v",
-				connectivityCheckAction.LogFilePath, err)
-			logger.Warning("output from stdout/stderr of executing commands on remotes nodes are lost!!!")
-		}
-		if executeLogWriter != nil {
-			executeLogWriter.Write(buf.Bytes())
-			executeLogWriter.Close()
-		}
-	}()
-
 	dstNode := connectivityCheckAction.DestinationNode
 	srcNode := connectivityCheckAction.SourceNode
 	logger.Infof("check network connectiviy from %s to %s", srcNode.Name, dstNode.Name)
@@ -194,19 +176,23 @@ func (e *connectivityCheckExecutor) Execute(act Action) *pb.Error {
 		}
 
 		captureChan := make(chan error)
-		dstStdout := []byte{}
-		dstStderr := []byte{}
-		captureStartTime := time.Now()
 		go func(errCh chan error) {
 			var e error
-			dstStdout, dstStderr, e = dstMachine.Run(strings.Join(captureCommand, " "))
+			dstCommand := command.NewShellCommand(dstMachine,
+				captureCommand[0], captureCommand[1:]...).
+				WithDescription("capture test packet").
+				WithExecuteLogWriter(act.GetExecuteLogBuffer())
+
+			_, _, e = dstCommand.Execute()
 			errCh <- e
 		}(captureChan)
 
 		// sleep one second to make sure that the packet is sent after capturing started
 		time.Sleep(time.Second)
-		sendStartTime := time.Now()
-		srcStdout, srcStderr, srcErr := srcMachine.Run(strings.Join(sendCommand, " "))
+		srcCommand := command.NewShellCommand(srcMachine, sendCommand[0], sendCommand[1:]...).
+			WithDescription("send test packet").
+			WithExecuteLogWriter(act.GetExecuteLogBuffer())
+		_, srcStderr, srcErr := srcCommand.Execute()
 		if srcErr != nil {
 			checkErr := &pb.Error{
 				Reason: reasonFailedToSendPacket,
@@ -221,28 +207,8 @@ func (e *connectivityCheckExecutor) Execute(act Action) *pb.Error {
 				continue
 			}
 		}
-		sendEndTime := time.Now()
-		utils.WriteExecuteLog(buf, &utils.ExecuteLogItem{
-			StartTime:   sendStartTime,
-			EndTime:     sendEndTime,
-			Command:     strings.Join(sendCommand, " "),
-			Stdout:      srcStdout,
-			Stderr:      srcStderr,
-			Err:         srcErr,
-			Description: "send test packet",
-		})
 
 		dstErr := <-captureChan
-		captureEndTime := time.Now()
-		utils.WriteExecuteLog(buf, &utils.ExecuteLogItem{
-			StartTime:   captureStartTime,
-			EndTime:     captureEndTime,
-			Command:     strings.Join(captureCommand, " "),
-			Stdout:      dstStdout,
-			Stderr:      dstStderr,
-			Err:         dstErr,
-			Description: "capture test packet",
-		})
 
 		if dstErr != nil {
 			checkErr := &pb.Error{

--- a/pkg/deploy/action/executor.go
+++ b/pkg/deploy/action/executor.go
@@ -204,6 +204,11 @@ func writeActionLogHeader(file *os.File, act Action) error {
 }
 
 func writeExecuteLogs(act Action) {
+
+	if act == nil {
+		logrus.Warning(consts.ErrEmptyAction)
+		return
+	}
 	logger := logrus.WithFields(logrus.Fields{
 		consts.LogFieldAction: act.GetName(),
 	})

--- a/pkg/deploy/action/executor.go
+++ b/pkg/deploy/action/executor.go
@@ -15,7 +15,9 @@ package action
 // limitations under the License.
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 
@@ -102,6 +104,8 @@ func ExecuteAction(act Action, wg *sync.WaitGroup) {
 		return
 	}
 
+	defer writeExecuteLogs(act)
+
 	if exeErr := executor.Execute(act); exeErr != nil {
 		act.SetStatus(ActionFailed)
 		act.SetErr(exeErr)
@@ -151,6 +155,10 @@ func setup(act Action) error {
 		}
 	}
 
+	// TODO: setup exeute log buffer with a thread safe ReadWriter.
+	if act.GetExecuteLogBuffer() == nil {
+		act.SetExecuteLogBuffer(&bytes.Buffer{})
+	}
 	return nil
 }
 
@@ -193,4 +201,43 @@ func writeActionLogHeader(file *os.File, act Action) error {
 	}
 
 	return nil
+}
+
+func writeExecuteLogs(act Action) {
+	logger := logrus.WithFields(logrus.Fields{
+		consts.LogFieldAction: act.GetName(),
+	})
+	logFilePath := act.GetLogFilePath()
+	if logFilePath == "" {
+		logger.Warning("action log file not specified")
+		return
+	}
+	file, err := os.OpenFile(
+		logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, os.FileMode(0644))
+	if err != nil {
+		logger.WithField("error", err).WithField("file", logFilePath).
+			Warningf("failed to open log file %s", logFilePath)
+		return
+	}
+	defer file.Close()
+	buf := act.GetExecuteLogBuffer()
+	if buf == nil {
+		logger.Warning("action did not write any execute log")
+		return
+	}
+
+	_, err = file.WriteString("# action execute logs: \n")
+	if err != nil {
+		logger.WithField("error", err).WithField("file", logFilePath).
+			Warningf("failed to write to log files %s", logFilePath)
+		return
+	}
+	_, err = io.Copy(file, buf)
+	if err != nil {
+		logger.WithField("error", err).WithField("file", logFilePath).
+			Warningf("failed to write to log files %s", logFilePath)
+		return
+	}
+	// TODO: run buf.Flush() here?
+	return
 }

--- a/pkg/deploy/action/executor.go
+++ b/pkg/deploy/action/executor.go
@@ -221,10 +221,6 @@ func writeExecuteLogs(act Action) {
 	}
 	defer file.Close()
 	buf := act.GetExecuteLogBuffer()
-	if buf == nil {
-		logger.Warning("action did not write any execute log")
-		return
-	}
 
 	_, err = file.WriteString("# action execute logs: \n")
 	if err != nil {
@@ -238,6 +234,4 @@ func writeExecuteLogs(act Action) {
 			Warningf("failed to write to log files %s", logFilePath)
 		return
 	}
-	// TODO: run buf.Flush() here?
-	return
 }

--- a/pkg/deploy/utils/execute_log.go
+++ b/pkg/deploy/utils/execute_log.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"time"
@@ -38,36 +39,38 @@ func WriteExecuteLog(w io.Writer, item *ExecuteLogItem) {
 	if w == nil || item == nil {
 		return
 	}
-	w.Write([]byte(consts.DashLine + "\n"))
+	buf := &bytes.Buffer{}
+	buf.Write([]byte(consts.DashLine + "\n"))
 	// write description
 	if item.Description != "" {
-		w.Write([]byte("[description] "))
-		w.Write([]byte(item.Description + "\n"))
+		buf.Write([]byte("[description] "))
+		buf.Write([]byte(item.Description + "\n"))
 	}
 	// write start time
 	startTimeMsg := fmt.Sprintf("[start time] %s\n", item.StartTime.Format(
 		"2006-01-02 15:04:05"))
-	w.Write([]byte(startTimeMsg))
+	buf.Write([]byte(startTimeMsg))
 	// write command
-	w.Write([]byte(fmt.Sprintf("[command] %s\n", item.Command)))
+	buf.Write([]byte(fmt.Sprintf("[command] %s\n", item.Command)))
 	// write stderr
-	w.Write([]byte("[stderr]\n"))
-	w.Write(item.Stderr)
-	w.Write([]byte("\n"))
+	buf.Write([]byte("[stderr]\n"))
+	buf.Write(item.Stderr)
+	buf.Write([]byte("\n"))
 	// write stdout
-	w.Write([]byte("[stdout]\n"))
-	w.Write(item.Stdout)
-	w.Write([]byte("\n"))
+	buf.Write([]byte("[stdout]\n"))
+	buf.Write(item.Stdout)
+	buf.Write([]byte("\n"))
 	// write error message
 	if item.Err != nil {
-		w.Write([]byte("[error]\n"))
-		w.Write([]byte(item.Err.Error()))
-		w.Write([]byte("\n"))
+		buf.Write([]byte("[error]\n"))
+		buf.Write([]byte(item.Err.Error()))
+		buf.Write([]byte("\n"))
 	}
 	// write end time
 	endTimeMsg := fmt.Sprintf("[end time] %s\n", item.EndTime.Format(
 		"2006-01-02 15:04:05"))
-	w.Write([]byte(endTimeMsg))
+	buf.Write([]byte(endTimeMsg))
 	// write an extra empty line
-	w.Write([]byte("\n"))
+	buf.Write([]byte("\n"))
+	w.Write(buf.Bytes())
 }


### PR DESCRIPTION
 - initialize execute log buffer and write logs in buffer into file  in executor 
 - add fields in `ShellCommand` and functions in method `shellCommand.Execute` to wirte execute logs of command