### PR TITLE
refactor(deploy-service): Renaming the check result, deploy status, deploy cluster status.

### DIFF
--- a/pkg/constant/check_result.go
+++ b/pkg/constant/check_result.go
@@ -19,8 +19,8 @@ type (
 )
 
 const (
-	CheckResultNotRunning CheckResult = "notRunning"
-	CheckResultChecking   CheckResult = "checking"
-	CheckResultPassed     CheckResult = "passed"
+	CheckResultPending    CheckResult = "pending"
+	CheckResultRunning    CheckResult = "running"
+	CheckResultSuccessful CheckResult = "successful"
 	CheckResultFailed     CheckResult = "failed"
 )

--- a/pkg/service/api/v1/deploy/checking.go
+++ b/pkg/service/api/v1/deploy/checking.go
@@ -47,7 +47,7 @@ func CheckNodeList(c *gin.Context) {
 		return
 	}
 
-	if wizardData.GetCheckResult() == constant.CheckResultChecking {
+	if wizardData.GetCheckResult() == constant.CheckResultRunning {
 		h.E(c, h.EStatusError.WithPayload("It was checking"))
 		return
 	}
@@ -128,7 +128,7 @@ func listenCheckNodesData() {
 
 	wizardData := wizard.GetCurrentWizard()
 	for {
-		if wizardData.GetCheckResult() != constant.CheckResultChecking {
+		if wizardData.GetCheckResult() != constant.CheckResultRunning {
 			break
 		}
 

--- a/pkg/service/api/v1/deploy/checking_test.go
+++ b/pkg/service/api/v1/deploy/checking_test.go
@@ -86,7 +86,7 @@ func TestGetCheckingNodeListResult(t *testing.T) {
 
 	wizard.ClearCurrentWizardData()
 	wizardData := wizard.GetCurrentWizard()
-	wizardData.ClusterCheckResult = constant.CheckResultPassed
+	wizardData.ClusterCheckResult = constant.CheckResultSuccessful
 	wizardData.Nodes = []*wizard.Node{
 		{
 			Name: "master1",
@@ -94,14 +94,14 @@ func TestGetCheckingNodeListResult(t *testing.T) {
 				CheckItems: []*wizard.CheckItem{
 					{
 						ItemName:    "check 1",
-						CheckResult: constant.CheckResultPassed,
+						CheckResult: constant.CheckResultSuccessful,
 					},
 					{
 						ItemName:    "check 2",
-						CheckResult: constant.CheckResultPassed,
+						CheckResult: constant.CheckResultSuccessful,
 					},
 				},
-				CheckResult: constant.CheckResultPassed,
+				CheckResult: constant.CheckResultSuccessful,
 			},
 		},
 	}
@@ -126,13 +126,13 @@ func TestGetCheckingNodeListResult(t *testing.T) {
 	assert.Equal(t, []api.CheckingItem{
 		{
 			CheckingPoint: "check 1",
-			Result:        constant.CheckResultPassed,
+			Result:        constant.CheckResultSuccessful,
 		},
 		{
 			CheckingPoint: "check 2",
-			Result:        constant.CheckResultPassed,
+			Result:        constant.CheckResultSuccessful,
 		},
 	}, checkData.Items)
 
-	assert.Equal(t, constant.CheckResultPassed, responseData.Result)
+	assert.Equal(t, constant.CheckResultSuccessful, responseData.Result)
 }

--- a/pkg/service/api/v1/deploy/convert.go
+++ b/pkg/service/api/v1/deploy/convert.go
@@ -91,8 +91,8 @@ func convertModelErrorToAPIError(detail *common.FailureDetail) *api.Error {
 func convertModelDeployClusterStatusToAPIDeployClusterStatus(status wizard.DeployClusterStatus) api.DeployClusterStatus {
 
 	switch status {
-	case wizard.DeployClusterStatusNotRunning:
-		return api.DeployClusterStatusNotRunning
+	case wizard.DeployClusterStatusPending:
+		return api.DeployClusterStatusPending
 	case wizard.DeployClusterStatusRunning:
 		return api.DeployClusterStatusRunning
 	case wizard.DeployClusterStatusSuccessful:
@@ -111,10 +111,10 @@ func convertModelDeployStatusToAPIDeployStatus(status wizard.DeployStatus) api.D
 	switch status {
 	case wizard.DeployStatusPending:
 		return api.DeployStatusPending
-	case wizard.DeployStatusDeploying:
-		return api.DeployStatusDeploying
-	case wizard.DeployStatusCompleted:
-		return api.DeployStatusCompleted
+	case wizard.DeployStatusRunning:
+		return api.DeployStatusRunning
+	case wizard.DeployStatusSuccessful:
+		return api.DeployStatusSuccessful
 	case wizard.DeployStatusFailed:
 		return api.DeployStatusFailed
 	case wizard.DeployStatusAborted:
@@ -238,7 +238,7 @@ func convertDeployControllerCheckResultToModelCheckResult(status string) constan
 
 	s := constant.CheckResult(status)
 	switch s {
-	case constant.CheckResultNotRunning, constant.CheckResultChecking, constant.CheckResultPassed, constant.CheckResultFailed:
+	case constant.CheckResultPending, constant.CheckResultRunning, constant.CheckResultSuccessful, constant.CheckResultFailed:
 		return s
 	}
 	return constant.CheckResult(fmt.Sprintf("unknown(%s)", status))
@@ -246,8 +246,8 @@ func convertDeployControllerCheckResultToModelCheckResult(status string) constan
 
 func convertDeployControllerDeployClusterStatusToModelDeployClusterStatus(status string) wizard.DeployClusterStatus {
 	switch status {
-	case string(wizard.DeployClusterStatusNotRunning):
-		return wizard.DeployClusterStatusNotRunning
+	case string(wizard.DeployClusterStatusPending):
+		return wizard.DeployClusterStatusPending
 	case string(wizard.DeployClusterStatusRunning):
 		return wizard.DeployClusterStatusRunning
 	case string(wizard.DeployClusterStatusSuccessful):
@@ -265,10 +265,10 @@ func convertDeployControllerDeployResultToModelDeployResult(status string) wizar
 	switch status {
 	case string(wizard.DeployStatusPending):
 		return wizard.DeployStatusPending
-	case string(wizard.DeployStatusDeploying):
-		return wizard.DeployStatusDeploying
-	case string(wizard.DeployStatusCompleted):
-		return wizard.DeployStatusCompleted
+	case string(wizard.DeployStatusRunning):
+		return wizard.DeployStatusRunning
+	case string(wizard.DeployStatusSuccessful):
+		return wizard.DeployStatusSuccessful
 	case string(wizard.DeployStatusFailed):
 		return wizard.DeployStatusFailed
 	case string(wizard.DeployStatusAborted):

--- a/pkg/service/api/v1/deploy/convert_test.go
+++ b/pkg/service/api/v1/deploy/convert_test.go
@@ -102,7 +102,7 @@ func TestConvertModelErrorToAPIError(t *testing.T) {
 
 func TestConvertModelDeployClusterStatusToAPIDeployClusterStatus(t *testing.T) {
 
-	assert.Equal(t, api.DeployClusterStatusNotRunning, convertModelDeployClusterStatusToAPIDeployClusterStatus(wizard.DeployClusterStatusNotRunning))
+	assert.Equal(t, api.DeployClusterStatusPending, convertModelDeployClusterStatusToAPIDeployClusterStatus(wizard.DeployClusterStatusPending))
 	assert.Equal(t, api.DeployClusterStatusRunning, convertModelDeployClusterStatusToAPIDeployClusterStatus(wizard.DeployClusterStatusRunning))
 	assert.Equal(t, api.DeployClusterStatusSuccessful, convertModelDeployClusterStatusToAPIDeployClusterStatus(wizard.DeployClusterStatusSuccessful))
 	assert.Equal(t, api.DeployClusterStatusFailed, convertModelDeployClusterStatusToAPIDeployClusterStatus(wizard.DeployClusterStatusFailed))
@@ -113,8 +113,8 @@ func TestConvertModelDeployClusterStatusToAPIDeployClusterStatus(t *testing.T) {
 func TestConvertModelDeployStatusToAPiDeployStatus(t *testing.T) {
 
 	assert.Equal(t, api.DeployStatusPending, convertModelDeployStatusToAPIDeployStatus(wizard.DeployStatusPending))
-	assert.Equal(t, api.DeployStatusDeploying, convertModelDeployStatusToAPIDeployStatus(wizard.DeployStatusDeploying))
-	assert.Equal(t, api.DeployStatusCompleted, convertModelDeployStatusToAPIDeployStatus(wizard.DeployStatusCompleted))
+	assert.Equal(t, api.DeployStatusRunning, convertModelDeployStatusToAPIDeployStatus(wizard.DeployStatusRunning))
+	assert.Equal(t, api.DeployStatusSuccessful, convertModelDeployStatusToAPIDeployStatus(wizard.DeployStatusSuccessful))
 	assert.Equal(t, api.DeployStatusFailed, convertModelDeployStatusToAPIDeployStatus(wizard.DeployStatusFailed))
 	assert.Equal(t, api.DeployStatusAborted, convertModelDeployStatusToAPIDeployStatus(wizard.DeployStatusAborted))
 	assert.Equal(t, api.DeployStatus("unknown(OtherType)"), convertModelDeployStatusToAPIDeployStatus("OtherType"))
@@ -216,16 +216,16 @@ ls3Q/5aeF7hB2MXfAAAAGEx1Y2t5Ym95c0BMdWNreU1hYy5sb2NhbAEC
 
 func TestConvertDeployControllerCheckResultToModelCheckResult(t *testing.T) {
 
-	assert.Equal(t, constant.CheckResultNotRunning, convertDeployControllerCheckResultToModelCheckResult(string(constant.CheckResultNotRunning)))
-	assert.Equal(t, constant.CheckResultChecking, convertDeployControllerCheckResultToModelCheckResult(string(constant.CheckResultChecking)))
-	assert.Equal(t, constant.CheckResultPassed, convertDeployControllerCheckResultToModelCheckResult(string(constant.CheckResultPassed)))
+	assert.Equal(t, constant.CheckResultPending, convertDeployControllerCheckResultToModelCheckResult(string(constant.CheckResultPending)))
+	assert.Equal(t, constant.CheckResultRunning, convertDeployControllerCheckResultToModelCheckResult(string(constant.CheckResultRunning)))
+	assert.Equal(t, constant.CheckResultSuccessful, convertDeployControllerCheckResultToModelCheckResult(string(constant.CheckResultSuccessful)))
 	assert.Equal(t, constant.CheckResultFailed, convertDeployControllerCheckResultToModelCheckResult(string(constant.CheckResultFailed)))
 	assert.Equal(t, constant.CheckResult("unknown(OtherType)"), convertDeployControllerCheckResultToModelCheckResult("OtherType"))
 }
 
 func TestConvertDeployControllerDeployClusterStatusToModelDeployClusterStatus(t *testing.T) {
 
-	assert.Equal(t, wizard.DeployClusterStatusNotRunning, convertDeployControllerDeployClusterStatusToModelDeployClusterStatus(string(wizard.DeployClusterStatusNotRunning)))
+	assert.Equal(t, wizard.DeployClusterStatusPending, convertDeployControllerDeployClusterStatusToModelDeployClusterStatus(string(wizard.DeployClusterStatusPending)))
 	assert.Equal(t, wizard.DeployClusterStatusRunning, convertDeployControllerDeployClusterStatusToModelDeployClusterStatus(string(wizard.DeployClusterStatusRunning)))
 	assert.Equal(t, wizard.DeployClusterStatusSuccessful, convertDeployControllerDeployClusterStatusToModelDeployClusterStatus(string(wizard.DeployClusterStatusSuccessful)))
 	assert.Equal(t, wizard.DeployClusterStatusFailed, convertDeployControllerDeployClusterStatusToModelDeployClusterStatus(string(wizard.DeployClusterStatusFailed)))
@@ -236,8 +236,8 @@ func TestConvertDeployControllerDeployClusterStatusToModelDeployClusterStatus(t 
 func TestConvertDeployControllerDeployResultToModelDeployResult(t *testing.T) {
 
 	assert.Equal(t, wizard.DeployStatusPending, convertDeployControllerDeployResultToModelDeployResult(string(wizard.DeployStatusPending)))
-	assert.Equal(t, wizard.DeployStatusDeploying, convertDeployControllerDeployResultToModelDeployResult(string(wizard.DeployStatusDeploying)))
-	assert.Equal(t, wizard.DeployStatusCompleted, convertDeployControllerDeployResultToModelDeployResult(string(wizard.DeployStatusCompleted)))
+	assert.Equal(t, wizard.DeployStatusRunning, convertDeployControllerDeployResultToModelDeployResult(string(wizard.DeployStatusRunning)))
+	assert.Equal(t, wizard.DeployStatusSuccessful, convertDeployControllerDeployResultToModelDeployResult(string(wizard.DeployStatusSuccessful)))
 	assert.Equal(t, wizard.DeployStatusFailed, convertDeployControllerDeployResultToModelDeployResult(string(wizard.DeployStatusFailed)))
 	assert.Equal(t, wizard.DeployStatusAborted, convertDeployControllerDeployResultToModelDeployResult(string(wizard.DeployStatusAborted)))
 	assert.Equal(t, wizard.DeployStatus("unknown(OtherType)"), convertDeployControllerDeployResultToModelDeployResult("OtherType"))

--- a/pkg/service/api/v1/deploy/deploy.go
+++ b/pkg/service/api/v1/deploy/deploy.go
@@ -47,7 +47,7 @@ func Deploy(c *gin.Context) {
 		return
 	}
 
-	if wizardData.GetCheckResult() != constant.CheckResultPassed {
+	if wizardData.GetCheckResult() != constant.CheckResultSuccessful {
 		h.E(c, h.EStatusError.WithPayload("current check result status is not passed"))
 		return
 	}

--- a/pkg/service/api/v1/deploy/deploy_test.go
+++ b/pkg/service/api/v1/deploy/deploy_test.go
@@ -85,11 +85,11 @@ func TestDeploy3(t *testing.T) {
 
 	wizard.ClearCurrentWizardData()
 	wizardData := wizard.GetCurrentWizard()
-	wizardData.ClusterCheckResult = constant.CheckResultPassed
+	wizardData.ClusterCheckResult = constant.CheckResultSuccessful
 	node := wizard.NewNode()
 	node.Name = "master1"
 	node.CheckReport = &wizard.CheckReport{
-		CheckResult: constant.CheckResultPassed,
+		CheckResult: constant.CheckResultSuccessful,
 	}
 	wizardData.Nodes = []*wizard.Node{
 		node,
@@ -122,11 +122,11 @@ func TestGetDeployReport(t *testing.T) {
 			DeploymentReports: map[constant.MachineRole]*wizard.DeploymentReport{
 				constant.MachineRoleMaster: {
 					Role:   constant.MachineRoleMaster,
-					Status: wizard.DeployStatusCompleted,
+					Status: wizard.DeployStatusSuccessful,
 				},
 				constant.MachineRoleEtcd: {
 					Role:   constant.MachineRoleEtcd,
-					Status: wizard.DeployStatusCompleted,
+					Status: wizard.DeployStatusSuccessful,
 				},
 			},
 		},
@@ -154,7 +154,7 @@ func TestGetDeployReport(t *testing.T) {
 			Nodes: []api.DeploymentNode{
 				{
 					Name:   "master1",
-					Status: api.DeployStatusCompleted,
+					Status: api.DeployStatusSuccessful,
 				},
 			},
 		},
@@ -163,7 +163,7 @@ func TestGetDeployReport(t *testing.T) {
 			Nodes: []api.DeploymentNode{
 				{
 					Name:   "master1",
-					Status: api.DeployStatusCompleted,
+					Status: api.DeployStatusSuccessful,
 				},
 			},
 		},

--- a/pkg/service/api/v1/deploy/progress_test.go
+++ b/pkg/service/api/v1/deploy/progress_test.go
@@ -48,8 +48,8 @@ func TestGetWizardProgress(t *testing.T) {
 	assert.Empty(t, responseData.NodesData)
 	assert.Empty(t, responseData.CheckingData)
 	assert.Empty(t, responseData.DeploymentData)
-	assert.Equal(t, constant.CheckResultNotRunning, responseData.CheckResult)
-	assert.Equal(t, api.DeployClusterStatusNotRunning, responseData.DeployClusterStatus)
+	assert.Equal(t, constant.CheckResultPending, responseData.CheckResult)
+	assert.Equal(t, api.DeployClusterStatusPending, responseData.DeployClusterStatus)
 }
 
 func TestGetWizardProgress2(t *testing.T) {
@@ -123,7 +123,7 @@ func TestGetWizardProgress3(t *testing.T) {
 			},
 			CheckReport: &wizard.CheckReport{
 				CheckItems:  make([]*wizard.CheckItem, 0),
-				CheckResult: constant.CheckResultNotRunning,
+				CheckResult: constant.CheckResultPending,
 			},
 		},
 	}
@@ -149,7 +149,7 @@ func TestGetWizardProgress4(t *testing.T) {
 
 	wizard.ClearCurrentWizardData()
 	wizardData := wizard.GetCurrentWizard()
-	wizardData.ClusterCheckResult = constant.CheckResultPassed
+	wizardData.ClusterCheckResult = constant.CheckResultSuccessful
 	wizardData.Nodes = []*wizard.Node{
 		{
 			Name: "master1",
@@ -157,14 +157,14 @@ func TestGetWizardProgress4(t *testing.T) {
 				CheckItems: []*wizard.CheckItem{
 					{
 						ItemName:    "check 1",
-						CheckResult: constant.CheckResultPassed,
+						CheckResult: constant.CheckResultSuccessful,
 					},
 					{
 						ItemName:    "check 2",
-						CheckResult: constant.CheckResultPassed,
+						CheckResult: constant.CheckResultSuccessful,
 					},
 				},
-				CheckResult: constant.CheckResultPassed,
+				CheckResult: constant.CheckResultSuccessful,
 			},
 		},
 	}
@@ -176,14 +176,14 @@ func TestGetWizardProgress4(t *testing.T) {
 	assert.Equal(t, []api.CheckingItem{
 		{
 			CheckingPoint: "check 1",
-			Result:        constant.CheckResultPassed,
+			Result:        constant.CheckResultSuccessful,
 		},
 		{
 			CheckingPoint: "check 2",
-			Result:        constant.CheckResultPassed,
+			Result:        constant.CheckResultSuccessful,
 		},
 	}, checkData.Items)
-	assert.Equal(t, constant.CheckResultPassed, responseData.CheckResult)
+	assert.Equal(t, constant.CheckResultSuccessful, responseData.CheckResult)
 }
 
 func TestGetWizardProgress5(t *testing.T) {
@@ -196,16 +196,16 @@ func TestGetWizardProgress5(t *testing.T) {
 			DeploymentReports: map[constant.MachineRole]*wizard.DeploymentReport{
 				constant.MachineRoleMaster: {
 					Role:   constant.MachineRoleMaster,
-					Status: wizard.DeployStatusCompleted,
+					Status: wizard.DeployStatusSuccessful,
 				},
 				constant.MachineRoleEtcd: {
 					Role:   constant.MachineRoleEtcd,
-					Status: wizard.DeployStatusCompleted,
+					Status: wizard.DeployStatusSuccessful,
 				},
 			},
 			CheckReport: &wizard.CheckReport{
 				CheckItems:  make([]*wizard.CheckItem, 0),
-				CheckResult: constant.CheckResultPassed,
+				CheckResult: constant.CheckResultSuccessful,
 			},
 		},
 	}
@@ -219,7 +219,7 @@ func TestGetWizardProgress5(t *testing.T) {
 			Nodes: []api.DeploymentNode{
 				{
 					Name:   "master1",
-					Status: api.DeployStatusCompleted,
+					Status: api.DeployStatusSuccessful,
 				},
 			},
 		},
@@ -228,7 +228,7 @@ func TestGetWizardProgress5(t *testing.T) {
 			Nodes: []api.DeploymentNode{
 				{
 					Name:   "master1",
-					Status: api.DeployStatusCompleted,
+					Status: api.DeployStatusSuccessful,
 				},
 			},
 		},

--- a/pkg/service/model/api/checking.go
+++ b/pkg/service/model/api/checking.go
@@ -21,7 +21,7 @@ import (
 type (
 	GetCheckingResultResponse struct {
 		Nodes  []CheckingResultResponseData `json:"nodes"`
-		Result constant.CheckResult         `json:"result" enums:"notRunning,checking,passed,failed"` // Overall inspection status
+		Result constant.CheckResult         `json:"result" enums:"pending,running,successful,failed"` // Overall inspection status
 	}
 
 	CheckingResultResponseData struct {
@@ -31,7 +31,7 @@ type (
 
 	CheckingItem struct {
 		CheckingPoint string               `json:"point"`                                            // Check point
-		Result        constant.CheckResult `json:"result" enums:"notRunning,checking,passed,failed"` // Checking Result
+		Result        constant.CheckResult `json:"result" enums:"pending,running,successful,failed"` // Checking Result
 		Error         *Error               `json:"error,omitempty"`
 	}
 )

--- a/pkg/service/model/api/deploy.go
+++ b/pkg/service/model/api/deploy.go
@@ -21,8 +21,8 @@ import (
 type (
 	GetDeploymentReportResponse struct {
 		Roles               []DeploymentResponseData `json:"roles"`
-		DeployClusterStatus DeployClusterStatus      `json:"deployClusterStatus" enums:"notRunning,running,successful,failed,workedButHaveError"` // The cluster deployment status
-		DeployClusterError  *Error                   `json:"deployClusterError,omitempty"`                                                        // Deploy cluster error message
+		DeployClusterStatus DeployClusterStatus      `json:"deployClusterStatus" enums:"pending,running,successful,failed,workedButHaveError"` // The cluster deployment status
+		DeployClusterError  *Error                   `json:"deployClusterError,omitempty"`                                                     // Deploy cluster error message
 	}
 
 	DeploymentResponseData struct {
@@ -31,8 +31,8 @@ type (
 	}
 
 	DeploymentNode struct {
-		Name   string       `json:"name"`                                                      // node name
-		Status DeployStatus `json:"result" enums:"pending,deploying,completed,failed,aborted"` // Checking Result
+		Name   string       `json:"name"`                                                     // node name
+		Status DeployStatus `json:"result" enums:"pending,running,successful,failed,aborted"` // Checking Result
 		Error  *Error       `json:"error,omitempty"`
 	}
 
@@ -41,13 +41,13 @@ type (
 )
 
 const (
-	DeployStatusPending   DeployStatus = "pending"
-	DeployStatusDeploying DeployStatus = "deploying"
-	DeployStatusCompleted DeployStatus = "completed"
-	DeployStatusFailed    DeployStatus = "failed"
-	DeployStatusAborted   DeployStatus = "aborted"
+	DeployStatusPending    DeployStatus = "pending"
+	DeployStatusRunning    DeployStatus = "running"
+	DeployStatusSuccessful DeployStatus = "successful"
+	DeployStatusFailed     DeployStatus = "failed"
+	DeployStatusAborted    DeployStatus = "aborted"
 
-	DeployClusterStatusNotRunning         DeployClusterStatus = "notRunning"
+	DeployClusterStatusPending            DeployClusterStatus = "pending"
 	DeployClusterStatusRunning            DeployClusterStatus = "running"
 	DeployClusterStatusSuccessful         DeployClusterStatus = "successful"
 	DeployClusterStatusFailed             DeployClusterStatus = "failed"

--- a/pkg/service/model/api/wizard.go
+++ b/pkg/service/model/api/wizard.go
@@ -26,8 +26,8 @@ type (
 		DeploymentData      []DeploymentResponseData     `json:"deploymentData"`                                                                                             // Deployment result
 		Progress            Progress                     `json:"progress" enums:"settingClusterInformation,settingNodesInformation,checkingNodes,deploying,deployCompleted"` // Wizard progress
 		Mode                WizardMode                   `json:"mode"`                                                                                                       // Wizard mode, normal or advanced
-		CheckResult         constant.CheckResult         `json:"checkResult" enums:"notRunning,checking,passed,failed"`                                                      // Nodes check result
-		DeployClusterStatus DeployClusterStatus          `json:"deployClusterStatus" enums:"notRunning,running,successful,failed,workedButHaveError"`                        // Cluster deployment status
+		CheckResult         constant.CheckResult         `json:"checkResult" enums:"pending,running,successful,failed"`                                                      // Nodes check result
+		DeployClusterStatus DeployClusterStatus          `json:"deployClusterStatus" enums:"pending,running,successful,failed,workedButHaveError"`                           // Cluster deployment status
 	}
 
 	Progress   string

--- a/pkg/service/model/wizard/cluster.go
+++ b/pkg/service/model/wizard/cluster.go
@@ -67,7 +67,7 @@ const (
 	KubeAPIServerConnectTypeKeepalived    KubeAPIServerConnectType = "keepalived"
 	KubeAPIServerConnectTypeLoadBalancer  KubeAPIServerConnectType = "loadbalancer"
 
-	DeployClusterStatusNotRunning         DeployClusterStatus = "notRunning"
+	DeployClusterStatusPending            DeployClusterStatus = "pending"
 	DeployClusterStatusRunning            DeployClusterStatus = "running"
 	DeployClusterStatusSuccessful         DeployClusterStatus = "successful"
 	DeployClusterStatusFailed             DeployClusterStatus = "failed"
@@ -91,8 +91,8 @@ func NewCluster() *Cluster {
 func (cluster *Cluster) init() {
 
 	cluster.Info = NewClusterInfo()
-	cluster.DeployClusterStatus = DeployClusterStatusNotRunning
-	cluster.ClusterCheckResult = constant.CheckResultNotRunning
+	cluster.DeployClusterStatus = DeployClusterStatusPending
+	cluster.ClusterCheckResult = constant.CheckResultPending
 	cluster.Nodes = make([]*Node, 0, 0)
 	cluster.Wizard = NewWizardData()
 	cluster.lock = &sync.RWMutex{}
@@ -256,11 +256,11 @@ func (cluster *Cluster) MarkNodeChecking() error {
 		return nil
 	}
 
-	if cluster.ClusterCheckResult == constant.CheckResultChecking {
+	if cluster.ClusterCheckResult == constant.CheckResultRunning {
 		return errors.New("was checking")
 	}
 
-	cluster.ClusterCheckResult = constant.CheckResultChecking
+	cluster.ClusterCheckResult = constant.CheckResultRunning
 
 	return nil
 }
@@ -274,7 +274,7 @@ func (cluster *Cluster) ClearClusterCheckingData() {
 		return
 	}
 
-	cluster.ClusterCheckResult = constant.CheckResultNotRunning
+	cluster.ClusterCheckResult = constant.CheckResultPending
 	cluster.ClusterCheckError = nil
 
 	for _, node := range cluster.Nodes {
@@ -305,7 +305,7 @@ func (cluster *Cluster) ClearClusterDeployData() {
 		return
 	}
 
-	cluster.DeployClusterStatus = DeployClusterStatusNotRunning
+	cluster.DeployClusterStatus = DeployClusterStatusPending
 	cluster.DeployClusterError = nil
 
 	for _, node := range cluster.Nodes {

--- a/pkg/service/model/wizard/cluster_test.go
+++ b/pkg/service/model/wizard/cluster_test.go
@@ -40,7 +40,7 @@ func TestNewClusterInfo(t *testing.T) {
 func TestGetCurrentWizard(t *testing.T) {
 
 	cluster := GetCurrentWizard()
-	assert.Equal(t, DeployClusterStatusNotRunning, cluster.DeployClusterStatus)
+	assert.Equal(t, DeployClusterStatusPending, cluster.DeployClusterStatus)
 	assert.NotNil(t, cluster.Wizard)
 	assert.NotNil(t, cluster.Nodes)
 	assert.NotNil(t, cluster.Info)
@@ -76,10 +76,10 @@ func TestCluster_GetCheckResult(t *testing.T) {
 	}{
 		{
 			Input: Cluster{
-				ClusterCheckResult: constant.CheckResultPassed,
+				ClusterCheckResult: constant.CheckResultSuccessful,
 				lock:               new(sync.RWMutex),
 			},
-			Want: constant.CheckResultPassed,
+			Want: constant.CheckResultSuccessful,
 		},
 		{
 			Input: Cluster{
@@ -111,10 +111,10 @@ func TestCluster_GetDeployClusterStatus(t *testing.T) {
 		},
 		{
 			Input: Cluster{
-				DeployClusterStatus: DeployClusterStatusNotRunning,
+				DeployClusterStatus: DeployClusterStatusPending,
 				lock:                new(sync.RWMutex),
 			},
-			Want: DeployClusterStatusNotRunning,
+			Want: DeployClusterStatusPending,
 		},
 	}
 
@@ -772,7 +772,7 @@ func TestCluster_MarkNodeChecking(t *testing.T) {
 		{
 			Input: Cluster{
 				Nodes:              []*Node{},
-				ClusterCheckResult: constant.CheckResultNotRunning,
+				ClusterCheckResult: constant.CheckResultPending,
 				lock:               new(sync.RWMutex),
 			},
 			Want: struct {
@@ -781,7 +781,7 @@ func TestCluster_MarkNodeChecking(t *testing.T) {
 			}{
 				Cluster: Cluster{
 					Nodes:              []*Node{},
-					ClusterCheckResult: constant.CheckResultNotRunning,
+					ClusterCheckResult: constant.CheckResultPending,
 					lock:               new(sync.RWMutex),
 				},
 				ReturnValue: nil,
@@ -797,7 +797,7 @@ func TestCluster_MarkNodeChecking(t *testing.T) {
 						},
 					},
 				},
-				ClusterCheckResult: constant.CheckResultNotRunning,
+				ClusterCheckResult: constant.CheckResultPending,
 				lock:               new(sync.RWMutex),
 			},
 			Want: struct {
@@ -813,7 +813,7 @@ func TestCluster_MarkNodeChecking(t *testing.T) {
 							},
 						},
 					},
-					ClusterCheckResult: constant.CheckResultChecking,
+					ClusterCheckResult: constant.CheckResultRunning,
 					lock:               new(sync.RWMutex),
 				},
 				ReturnValue: nil,
@@ -829,7 +829,7 @@ func TestCluster_MarkNodeChecking(t *testing.T) {
 						},
 					},
 				},
-				ClusterCheckResult: constant.CheckResultChecking,
+				ClusterCheckResult: constant.CheckResultRunning,
 				lock:               new(sync.RWMutex),
 			},
 			Want: struct {
@@ -845,7 +845,7 @@ func TestCluster_MarkNodeChecking(t *testing.T) {
 							},
 						},
 					},
-					ClusterCheckResult: constant.CheckResultChecking,
+					ClusterCheckResult: constant.CheckResultRunning,
 					lock:               new(sync.RWMutex),
 				},
 				ReturnValue: errors.New("was checking"),
@@ -869,12 +869,12 @@ func TestCluster_ClearClusterCheckingData(t *testing.T) {
 		{
 			Input: Cluster{
 				Nodes:              []*Node{},
-				ClusterCheckResult: constant.CheckResultNotRunning,
+				ClusterCheckResult: constant.CheckResultPending,
 				lock:               new(sync.RWMutex),
 			},
 			Want: Cluster{
 				Nodes:              []*Node{},
-				ClusterCheckResult: constant.CheckResultNotRunning,
+				ClusterCheckResult: constant.CheckResultPending,
 				lock:               new(sync.RWMutex),
 			},
 		},
@@ -886,7 +886,7 @@ func TestCluster_ClearClusterCheckingData(t *testing.T) {
 						CheckReport: &CheckReport{},
 					},
 				},
-				ClusterCheckResult: constant.CheckResultChecking,
+				ClusterCheckResult: constant.CheckResultRunning,
 				lock:               new(sync.RWMutex),
 			},
 			Want: Cluster{
@@ -895,11 +895,11 @@ func TestCluster_ClearClusterCheckingData(t *testing.T) {
 						Name: "node2",
 						CheckReport: &CheckReport{
 							CheckItems:  make([]*CheckItem, 0, 0),
-							CheckResult: constant.CheckResultNotRunning,
+							CheckResult: constant.CheckResultPending,
 						},
 					},
 				},
-				ClusterCheckResult: constant.CheckResultNotRunning,
+				ClusterCheckResult: constant.CheckResultPending,
 				lock:               new(sync.RWMutex),
 			},
 		},
@@ -929,14 +929,14 @@ func TestCluster_SetClusterCheckResult(t *testing.T) {
 				FailureDetail *common.FailureDetail
 			}{
 				Cluster: Cluster{
-					ClusterCheckResult: constant.CheckResultChecking,
+					ClusterCheckResult: constant.CheckResultRunning,
 					lock:               new(sync.RWMutex),
 				},
-				CheckResult:   constant.CheckResultPassed,
+				CheckResult:   constant.CheckResultSuccessful,
 				FailureDetail: nil,
 			},
 			Want: Cluster{
-				ClusterCheckResult: constant.CheckResultPassed,
+				ClusterCheckResult: constant.CheckResultSuccessful,
 				lock:               new(sync.RWMutex),
 			},
 		},
@@ -947,7 +947,7 @@ func TestCluster_SetClusterCheckResult(t *testing.T) {
 				FailureDetail *common.FailureDetail
 			}{
 				Cluster: Cluster{
-					ClusterCheckResult: constant.CheckResultChecking,
+					ClusterCheckResult: constant.CheckResultRunning,
 					lock:               new(sync.RWMutex),
 				},
 				CheckResult: constant.CheckResultFailed,
@@ -1018,7 +1018,7 @@ func TestCluster_ClearClusterDeployData(t *testing.T) {
 						DeploymentReports: map[constant.MachineRole]*DeploymentReport{},
 					},
 				},
-				DeployClusterStatus: DeployClusterStatusNotRunning,
+				DeployClusterStatus: DeployClusterStatusPending,
 				lock:                new(sync.RWMutex),
 			},
 		},
@@ -1045,7 +1045,7 @@ func TestCluster_ClearClusterDeployData(t *testing.T) {
 						DeploymentReports: map[constant.MachineRole]*DeploymentReport{},
 					},
 				},
-				DeployClusterStatus: DeployClusterStatusNotRunning,
+				DeployClusterStatus: DeployClusterStatusPending,
 				lock:                new(sync.RWMutex),
 			},
 		},
@@ -1092,7 +1092,7 @@ func TestCluster_MarkNodeDeploying(t *testing.T) {
 						Name: "node2",
 					},
 				},
-				DeployClusterStatus: DeployClusterStatusNotRunning,
+				DeployClusterStatus: DeployClusterStatusPending,
 				lock:                new(sync.RWMutex),
 			},
 			Want: struct {

--- a/pkg/service/model/wizard/node.go
+++ b/pkg/service/model/wizard/node.go
@@ -94,11 +94,11 @@ const (
 	TaintEffectNoExecute        TaintEffect = "NoExecute"
 	TaintEffectPreferNoSchedule TaintEffect = "PreferNoSchedule"
 
-	DeployStatusPending   DeployStatus = "pending"
-	DeployStatusDeploying DeployStatus = "deploying"
-	DeployStatusCompleted DeployStatus = "completed"
-	DeployStatusFailed    DeployStatus = "failed"
-	DeployStatusAborted   DeployStatus = "aborted"
+	DeployStatusPending    DeployStatus = "pending"
+	DeployStatusRunning    DeployStatus = "running"
+	DeployStatusSuccessful DeployStatus = "successful"
+	DeployStatusFailed     DeployStatus = "failed"
+	DeployStatusAborted    DeployStatus = "aborted"
 
 	DefaultDockerRootDirectory = "/var/lib/docker"
 	DefaultUsername            = "root"
@@ -214,12 +214,12 @@ func NewCheckItem() *CheckItem {
 
 func (item *CheckItem) init() {
 
-	item.CheckResult = constant.CheckResultNotRunning
+	item.CheckResult = constant.CheckResultPending
 }
 
 func (report *CheckReport) init() {
 
-	report.CheckResult = constant.CheckResultNotRunning
+	report.CheckResult = constant.CheckResultPending
 	report.CheckedError = nil
 	report.CheckItems = make([]*CheckItem, 0, 0)
 }

--- a/pkg/service/model/wizard/node_test.go
+++ b/pkg/service/model/wizard/node_test.go
@@ -46,7 +46,7 @@ func TestNewDeploymentReport(t *testing.T) {
 func TestNewCheckItem(t *testing.T) {
 
 	item := NewCheckItem()
-	assert.Equal(t, constant.CheckResultNotRunning, item.CheckResult)
+	assert.Equal(t, constant.CheckResultPending, item.CheckResult)
 }
 
 func TestNode_SetCheckResult(t *testing.T) {
@@ -67,15 +67,15 @@ func TestNode_SetCheckResult(t *testing.T) {
 			}{
 				Node: &Node{
 					CheckReport: &CheckReport{
-						CheckResult: constant.CheckResultChecking,
+						CheckResult: constant.CheckResultRunning,
 					},
 				},
-				CheckResult:   constant.CheckResultPassed,
+				CheckResult:   constant.CheckResultSuccessful,
 				FailureDetail: nil,
 			},
 			Want: &Node{
 				CheckReport: &CheckReport{
-					CheckResult: constant.CheckResultPassed,
+					CheckResult: constant.CheckResultSuccessful,
 				},
 			},
 		},
@@ -87,7 +87,7 @@ func TestNode_SetCheckResult(t *testing.T) {
 			}{
 				Node: &Node{
 					CheckReport: &CheckReport{
-						CheckResult: constant.CheckResultChecking,
+						CheckResult: constant.CheckResultRunning,
 					},
 				},
 				CheckResult: constant.CheckResultFailed,
@@ -143,7 +143,7 @@ func TestNode_SetCheckItem(t *testing.T) {
 					},
 				},
 				ItemName:      "item 1",
-				CheckResult:   constant.CheckResultChecking,
+				CheckResult:   constant.CheckResultRunning,
 				FailureDetail: nil,
 			},
 			Want: &Node{
@@ -151,7 +151,7 @@ func TestNode_SetCheckItem(t *testing.T) {
 					CheckItems: []*CheckItem{
 						{
 							ItemName:    "item 1",
-							CheckResult: constant.CheckResultChecking,
+							CheckResult: constant.CheckResultRunning,
 							Error:       nil,
 						},
 					},
@@ -170,14 +170,14 @@ func TestNode_SetCheckItem(t *testing.T) {
 						CheckItems: []*CheckItem{
 							{
 								ItemName:    "item 1",
-								CheckResult: constant.CheckResultChecking,
+								CheckResult: constant.CheckResultRunning,
 								Error:       nil,
 							},
 						},
 					},
 				},
 				ItemName:      "item 1",
-				CheckResult:   constant.CheckResultPassed,
+				CheckResult:   constant.CheckResultSuccessful,
 				FailureDetail: nil,
 			},
 			Want: &Node{
@@ -185,7 +185,7 @@ func TestNode_SetCheckItem(t *testing.T) {
 					CheckItems: []*CheckItem{
 						{
 							ItemName:    "item 1",
-							CheckResult: constant.CheckResultPassed,
+							CheckResult: constant.CheckResultSuccessful,
 							Error:       nil,
 						},
 					},
@@ -204,7 +204,7 @@ func TestNode_SetCheckItem(t *testing.T) {
 						CheckItems: []*CheckItem{
 							{
 								ItemName:    "item 2",
-								CheckResult: constant.CheckResultChecking,
+								CheckResult: constant.CheckResultRunning,
 								Error:       nil,
 							},
 						},
@@ -248,7 +248,7 @@ func TestNode_SetCheckItem(t *testing.T) {
 						CheckItems: []*CheckItem{
 							{
 								ItemName:    "item 1",
-								CheckResult: constant.CheckResultChecking,
+								CheckResult: constant.CheckResultRunning,
 								Error:       nil,
 							},
 						},
@@ -268,7 +268,7 @@ func TestNode_SetCheckItem(t *testing.T) {
 					CheckItems: []*CheckItem{
 						{
 							ItemName:    "item 1",
-							CheckResult: constant.CheckResultChecking,
+							CheckResult: constant.CheckResultRunning,
 							Error:       nil,
 						},
 						{
@@ -346,14 +346,14 @@ func TestNode_SetDeployResult(t *testing.T) {
 					},
 				},
 				Role:          constant.MachineRoleMaster,
-				Status:        DeployStatusDeploying,
+				Status:        DeployStatusRunning,
 				FailureDetail: nil,
 			},
 			Want: &Node{
 				DeploymentReports: map[constant.MachineRole]*DeploymentReport{
 					constant.MachineRoleMaster: {
 						Role:   constant.MachineRoleMaster,
-						Status: DeployStatusDeploying,
+						Status: DeployStatusRunning,
 						Error:  nil,
 					},
 				},
@@ -370,7 +370,7 @@ func TestNode_SetDeployResult(t *testing.T) {
 					DeploymentReports: map[constant.MachineRole]*DeploymentReport{
 						constant.MachineRoleMaster: {
 							Role:   constant.MachineRoleMaster,
-							Status: DeployStatusDeploying,
+							Status: DeployStatusRunning,
 							Error:  nil,
 						},
 					},
@@ -410,25 +410,25 @@ func TestNode_SetDeployResult(t *testing.T) {
 					DeploymentReports: map[constant.MachineRole]*DeploymentReport{
 						constant.MachineRoleMaster: {
 							Role:   constant.MachineRoleMaster,
-							Status: DeployStatusDeploying,
+							Status: DeployStatusRunning,
 							Error:  nil,
 						},
 					},
 				},
 				Role:          constant.MachineRoleEtcd,
-				Status:        DeployStatusCompleted,
+				Status:        DeployStatusSuccessful,
 				FailureDetail: nil,
 			},
 			Want: &Node{
 				DeploymentReports: map[constant.MachineRole]*DeploymentReport{
 					constant.MachineRoleMaster: {
 						Role:   constant.MachineRoleMaster,
-						Status: DeployStatusDeploying,
+						Status: DeployStatusRunning,
 						Error:  nil,
 					},
 					constant.MachineRoleEtcd: {
 						Role:   constant.MachineRoleEtcd,
-						Status: DeployStatusCompleted,
+						Status: DeployStatusSuccessful,
 						Error:  nil,
 					},
 				},

--- a/pkg/service/swaggerdocs/docs.go
+++ b/pkg/service/swaggerdocs/docs.go
@@ -1039,9 +1039,9 @@ var doc = `{
                     "description": "Checking Result",
                     "type": "string",
                     "enum": [
-                        "notRunning",
-                        "checking",
-                        "passed",
+                        "pending",
+                        "running",
+                        "successful",
                         "failed"
                     ]
                 }
@@ -1191,8 +1191,8 @@ var doc = `{
                     "type": "string",
                     "enum": [
                         "pending",
-                        "deploying",
-                        "completed",
+                        "running",
+                        "successful",
                         "failed",
                         "aborted"
                     ]
@@ -1252,9 +1252,9 @@ var doc = `{
                     "description": "Overall inspection status",
                     "type": "string",
                     "enum": [
-                        "notRunning",
-                        "checking",
-                        "passed",
+                        "pending",
+                        "running",
+                        "successful",
                         "failed"
                     ]
                 }
@@ -1272,7 +1272,7 @@ var doc = `{
                     "description": "The cluster deployment status",
                     "type": "string",
                     "enum": [
-                        "notRunning",
+                        "pending",
                         "running",
                         "successful",
                         "failed",
@@ -1317,9 +1317,9 @@ var doc = `{
                     "description": "Nodes check result",
                     "type": "string",
                     "enum": [
-                        "notRunning",
-                        "checking",
-                        "passed",
+                        "pending",
+                        "running",
+                        "successful",
                         "failed"
                     ]
                 },
@@ -1339,7 +1339,7 @@ var doc = `{
                     "description": "Cluster deployment status",
                     "type": "string",
                     "enum": [
-                        "notRunning",
+                        "pending",
                         "running",
                         "successful",
                         "failed",

--- a/pkg/service/swaggerdocs/swagger.json
+++ b/pkg/service/swaggerdocs/swagger.json
@@ -1025,9 +1025,9 @@
                     "description": "Checking Result",
                     "type": "string",
                     "enum": [
-                        "notRunning",
-                        "checking",
-                        "passed",
+                        "pending",
+                        "running",
+                        "successful",
                         "failed"
                     ]
                 }
@@ -1177,8 +1177,8 @@
                     "type": "string",
                     "enum": [
                         "pending",
-                        "deploying",
-                        "completed",
+                        "running",
+                        "successful",
                         "failed",
                         "aborted"
                     ]
@@ -1238,9 +1238,9 @@
                     "description": "Overall inspection status",
                     "type": "string",
                     "enum": [
-                        "notRunning",
-                        "checking",
-                        "passed",
+                        "pending",
+                        "running",
+                        "successful",
                         "failed"
                     ]
                 }
@@ -1258,7 +1258,7 @@
                     "description": "The cluster deployment status",
                     "type": "string",
                     "enum": [
-                        "notRunning",
+                        "pending",
                         "running",
                         "successful",
                         "failed",
@@ -1303,9 +1303,9 @@
                     "description": "Nodes check result",
                     "type": "string",
                     "enum": [
-                        "notRunning",
-                        "checking",
-                        "passed",
+                        "pending",
+                        "running",
+                        "successful",
                         "failed"
                     ]
                 },
@@ -1325,7 +1325,7 @@
                     "description": "Cluster deployment status",
                     "type": "string",
                     "enum": [
-                        "notRunning",
+                        "pending",
                         "running",
                         "successful",
                         "failed",

--- a/pkg/service/swaggerdocs/swagger.yaml
+++ b/pkg/service/swaggerdocs/swagger.yaml
@@ -21,9 +21,9 @@ definitions:
       result:
         description: Checking Result
         enum:
-        - notRunning
-        - checking
-        - passed
+        - pending
+        - running
+        - successful
         - failed
         type: string
     type: object
@@ -137,8 +137,8 @@ definitions:
         description: Checking Result
         enum:
         - pending
-        - deploying
-        - completed
+        - running
+        - successful
         - failed
         - aborted
         type: string
@@ -180,9 +180,9 @@ definitions:
       result:
         description: Overall inspection status
         enum:
-        - notRunning
-        - checking
-        - passed
+        - pending
+        - running
+        - successful
         - failed
         type: string
     type: object
@@ -195,7 +195,7 @@ definitions:
       deployClusterStatus:
         description: The cluster deployment status
         enum:
-        - notRunning
+        - pending
         - running
         - successful
         - failed
@@ -226,9 +226,9 @@ definitions:
       checkResult:
         description: Nodes check result
         enum:
-        - notRunning
-        - checking
-        - passed
+        - pending
+        - running
+        - successful
         - failed
         type: string
       checkingData:
@@ -243,7 +243,7 @@ definitions:
       deployClusterStatus:
         description: Cluster deployment status
         enum:
-        - notRunning
+        - pending
         - running
         - successful
         - failed


### PR DESCRIPTION
Try to unified the constants name.

赶紧看一下。