### PR TITLE
feat(deploy-service): Added API definition for cluster configuration check result when get checking #OTWO-37

### DIFF
--- a/pkg/constant/check_result.go
+++ b/pkg/constant/check_result.go
@@ -22,6 +22,7 @@ const (
 	CheckResultPending              CheckResult = "pending"
 	CheckResultRunning              CheckResult = "running"
 	CheckResultSuccessful           CheckResult = "successful"
+	CheckResultWarning              CheckResult = "warning"
 	CheckResultFailed               CheckResult = "failed"
 	CheckResultDeployServiceUnknown CheckResult = "unknown(deploy)"
 )

--- a/pkg/service/model/api/checking.go
+++ b/pkg/service/model/api/checking.go
@@ -20,8 +20,9 @@ import (
 
 type (
 	GetCheckingResultResponse struct {
-		Nodes  []CheckingResultResponseData `json:"nodes"`
-		Result constant.CheckResult         `json:"result" enums:"pending,running,successful,failed"` // Overall inspection status
+		Nodes   []CheckingResultResponseData `json:"nodes"`
+		Cluster CheckClusterResponseData     `json:"cluster"`
+		Result  constant.CheckResult         `json:"result" enums:"pending,running,successful,failed"` // Overall inspection status
 	}
 
 	CheckingResultResponseData struct {
@@ -33,5 +34,10 @@ type (
 		CheckingPoint string               `json:"point"`                                            // Check point
 		Result        constant.CheckResult `json:"result" enums:"pending,running,successful,failed"` // Checking Result
 		Error         *Error               `json:"error,omitempty"`
+	}
+
+	CheckClusterResponseData struct {
+		WarningItems []*CheckingItem `json:"warningItems"`
+		ErrorItems   []*CheckingItem `json:"errorItems"`
 	}
 )

--- a/pkg/service/model/api/checking.go
+++ b/pkg/service/model/api/checking.go
@@ -22,7 +22,7 @@ type (
 	GetCheckingResultResponse struct {
 		Nodes   []CheckingResultResponseData `json:"nodes"`
 		Cluster CheckClusterResponseData     `json:"cluster"`
-		Result  constant.CheckResult         `json:"result" enums:"pending,running,successful,failed"` // Overall inspection status
+		Result  constant.CheckResult         `json:"result" enums:"pending,running,successful,warning,failed"` // Overall inspection status
 	}
 
 	CheckingResultResponseData struct {
@@ -31,13 +31,12 @@ type (
 	}
 
 	CheckingItem struct {
-		CheckingPoint string               `json:"point"`                                            // Check point
-		Result        constant.CheckResult `json:"result" enums:"pending,running,successful,failed"` // Checking Result
+		CheckingPoint string               `json:"point"`                                                    // Check point
+		Result        constant.CheckResult `json:"result" enums:"pending,running,successful,warning,failed"` // Checking Result
 		Error         *Error               `json:"error,omitempty"`
 	}
 
 	CheckClusterResponseData struct {
-		WarningItems []*CheckingItem `json:"warningItems"`
-		ErrorItems   []*CheckingItem `json:"errorItems"`
+		Items []*CheckingItem `json:"items"`
 	}
 )

--- a/pkg/service/swaggerdocs/docs.go
+++ b/pkg/service/swaggerdocs/docs.go
@@ -1024,6 +1024,23 @@ var doc = `{
                 }
             }
         },
+        "api.CheckClusterResponseData": {
+            "type": "object",
+            "properties": {
+                "errorItems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.CheckingItem"
+                    }
+                },
+                "warningItems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.CheckingItem"
+                    }
+                }
+            }
+        },
         "api.CheckingItem": {
             "type": "object",
             "properties": {
@@ -1242,6 +1259,10 @@ var doc = `{
         "api.GetCheckingResultResponse": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "type": "object",
+                    "$ref": "#/definitions/api.CheckClusterResponseData"
+                },
                 "nodes": {
                     "type": "array",
                     "items": {

--- a/pkg/service/swaggerdocs/docs.go
+++ b/pkg/service/swaggerdocs/docs.go
@@ -1027,13 +1027,7 @@ var doc = `{
         "api.CheckClusterResponseData": {
             "type": "object",
             "properties": {
-                "errorItems": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/api.CheckingItem"
-                    }
-                },
-                "warningItems": {
+                "items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/api.CheckingItem"
@@ -1059,6 +1053,7 @@ var doc = `{
                         "pending",
                         "running",
                         "successful",
+                        "warning",
                         "failed"
                     ]
                 }
@@ -1276,6 +1271,7 @@ var doc = `{
                         "pending",
                         "running",
                         "successful",
+                        "warning",
                         "failed"
                     ]
                 }

--- a/pkg/service/swaggerdocs/swagger.json
+++ b/pkg/service/swaggerdocs/swagger.json
@@ -1010,6 +1010,23 @@
                 }
             }
         },
+        "api.CheckClusterResponseData": {
+            "type": "object",
+            "properties": {
+                "errorItems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.CheckingItem"
+                    }
+                },
+                "warningItems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.CheckingItem"
+                    }
+                }
+            }
+        },
         "api.CheckingItem": {
             "type": "object",
             "properties": {
@@ -1228,6 +1245,10 @@
         "api.GetCheckingResultResponse": {
             "type": "object",
             "properties": {
+                "cluster": {
+                    "type": "object",
+                    "$ref": "#/definitions/api.CheckClusterResponseData"
+                },
                 "nodes": {
                     "type": "array",
                     "items": {

--- a/pkg/service/swaggerdocs/swagger.json
+++ b/pkg/service/swaggerdocs/swagger.json
@@ -1013,13 +1013,7 @@
         "api.CheckClusterResponseData": {
             "type": "object",
             "properties": {
-                "errorItems": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/api.CheckingItem"
-                    }
-                },
-                "warningItems": {
+                "items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/api.CheckingItem"
@@ -1045,6 +1039,7 @@
                         "pending",
                         "running",
                         "successful",
+                        "warning",
                         "failed"
                     ]
                 }
@@ -1262,6 +1257,7 @@
                         "pending",
                         "running",
                         "successful",
+                        "warning",
                         "failed"
                     ]
                 }

--- a/pkg/service/swaggerdocs/swagger.yaml
+++ b/pkg/service/swaggerdocs/swagger.yaml
@@ -10,6 +10,17 @@ definitions:
     - key
     - value
     type: object
+  api.CheckClusterResponseData:
+    properties:
+      errorItems:
+        items:
+          $ref: '#/definitions/api.CheckingItem'
+        type: array
+      warningItems:
+        items:
+          $ref: '#/definitions/api.CheckingItem'
+        type: array
+    type: object
   api.CheckingItem:
     properties:
       error:
@@ -173,6 +184,9 @@ definitions:
     type: object
   api.GetCheckingResultResponse:
     properties:
+      cluster:
+        $ref: '#/definitions/api.CheckClusterResponseData'
+        type: object
       nodes:
         items:
           $ref: '#/definitions/api.CheckingResultResponseData'

--- a/pkg/service/swaggerdocs/swagger.yaml
+++ b/pkg/service/swaggerdocs/swagger.yaml
@@ -12,11 +12,7 @@ definitions:
     type: object
   api.CheckClusterResponseData:
     properties:
-      errorItems:
-        items:
-          $ref: '#/definitions/api.CheckingItem'
-        type: array
-      warningItems:
+      items:
         items:
           $ref: '#/definitions/api.CheckingItem'
         type: array
@@ -35,6 +31,7 @@ definitions:
         - pending
         - running
         - successful
+        - warning
         - failed
         type: string
     type: object
@@ -197,6 +194,7 @@ definitions:
         - pending
         - running
         - successful
+        - warning
         - failed
         type: string
     type: object


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/195125/71714400-ae98e480-2e48-11ea-89bf-4e274b5371bf.png)

在GET /api/v1/deploy/wizard/checks 中增加 `cluster` 字段

同时对 `constant.CheckResult` 增加 `CheckResultWarning` 类型，用于标识检查Warning，但是可以继续下一步。