### PR TITLE
feature(deploy/task): make deploy task continue to run if encounts non-fatal error

### DIFF
--- a/pkg/deploy/task/deploy_master_processor.go
+++ b/pkg/deploy/task/deploy_master_processor.go
@@ -71,7 +71,7 @@ func (p *deployMasterProcessor) ProcessStatus(t Task) error {
 	for _, subTask := range t.GetSubTasks() {
 		if _, ok := subTask.(*InitMasterTask); ok && subTask.GetStatus() == TaskSuccessful {
 			// If init-master sub task is successful, we can ignore join-master sub task's failure
-			t.SetFailureCanbeIgnored(true)
+			t.SetFailureCanBeIgnored(true)
 			break
 		}
 	}

--- a/pkg/deploy/task/deploy_master_processor.go
+++ b/pkg/deploy/task/deploy_master_processor.go
@@ -62,6 +62,23 @@ func (p *deployMasterProcessor) SplitTask(t Task) error {
 	return nil
 }
 
+func (p *deployMasterProcessor) ProcessStatus(t Task) error {
+	_, err := p.verifyTask(t)
+	if err != nil {
+		return err
+	}
+
+	for _, subTask := range t.GetSubTasks() {
+		if _, ok := subTask.(*InitMasterTask); ok && subTask.GetStatus() == TaskSuccessful {
+			// If init-master sub task is successful, we can ignore join-master sub task's failure
+			t.SetFailureCanbeIgnored(true)
+			break
+		}
+	}
+
+	return nil
+}
+
 // Verify if the task is valid.
 func (p *deployMasterProcessor) verifyTask(t Task) (*deployMasterTask, error) {
 	if t == nil {

--- a/pkg/deploy/task/deploy_worker_task.go
+++ b/pkg/deploy/task/deploy_worker_task.go
@@ -55,13 +55,14 @@ func NewDeployWorkerTask(taskName string, taskConfig *DeployWorkerTaskConfig) (T
 
 	task := &deployWorkerTask{
 		Base: Base{
-			Name:              taskName,
-			TaskType:          TaskTypeDeployWorker,
-			Status:            TaskPending,
-			LogFileDir:        GenTaskLogFileDir(taskConfig.LogFileBasePath, taskName), // /app/deploy/logs/unknown/deploy-worker
-			CreationTimestamp: time.Now(),
-			Priority:          taskConfig.Priority,
-			Parent:            taskConfig.Parent,
+			Name:                taskName,
+			TaskType:            TaskTypeDeployWorker,
+			Status:              TaskPending,
+			LogFileDir:          GenTaskLogFileDir(taskConfig.LogFileBasePath, taskName), // /app/deploy/logs/unknown/deploy-worker
+			CreationTimestamp:   time.Now(),
+			Priority:            taskConfig.Priority,
+			Parent:              taskConfig.Parent,
+			FailureCanbeIgnored: true,
 		},
 		Nodes:       taskConfig.Nodes,
 		Cluster:     taskConfig.ClusterConfig,

--- a/pkg/deploy/task/deploy_worker_task.go
+++ b/pkg/deploy/task/deploy_worker_task.go
@@ -62,7 +62,7 @@ func NewDeployWorkerTask(taskName string, taskConfig *DeployWorkerTaskConfig) (T
 			CreationTimestamp:   time.Now(),
 			Priority:            taskConfig.Priority,
 			Parent:              taskConfig.Parent,
-			FailureCanbeIgnored: true,
+			FailureCanBeIgnored: true,
 		},
 		Nodes:       taskConfig.Nodes,
 		Cluster:     taskConfig.ClusterConfig,

--- a/pkg/deploy/task/processor.go
+++ b/pkg/deploy/task/processor.go
@@ -249,7 +249,7 @@ func executeSubTasks(t Task) error {
 		// If any sub task in the current task group was failed and its failure can't be ignored,
 		// stop to execut other task groups and return.
 		for _, aSubTask := range taskGp {
-			if aSubTask.GetStatus() != TaskSuccessful && !aSubTask.GetFailureCanbeIgnored() {
+			if aSubTask.GetStatus() != TaskSuccessful && !aSubTask.GetFailureCanBeIgnored() {
 				return fmt.Errorf("[%s] sub task was failed", aSubTask.GetName())
 			}
 		}

--- a/pkg/deploy/task/processor.go
+++ b/pkg/deploy/task/processor.go
@@ -40,6 +40,13 @@ type ExtraResult interface {
 	ProcessExtraResult(task Task) error
 }
 
+// StatusHandler defines the interface to process the task's status, this let the concrete processor
+// has a chance to handle special case for task status
+type StatusHandler interface {
+	// ProcessStatus is supposed to be called after summarizing the task status.
+	ProcessStatus(task Task) error
+}
+
 var _processRegistry map[Type]Processor
 
 // RegisterProcessor is to register a Processor for a task type
@@ -239,12 +246,10 @@ func executeSubTasks(t Task) error {
 		}
 		wg.Wait()
 
-		// If any sub task in the current task group was failed, stop to execut other task groups and return.
+		// If any sub task in the current task group was failed and its failure can't be ignored,
+		// stop to execut other task groups and return.
 		for _, aSubTask := range taskGp {
-			if err := statTask(aSubTask); err != nil {
-				return err
-			}
-			if aSubTask.GetStatus() != TaskSuccessful {
+			if aSubTask.GetStatus() != TaskSuccessful && !aSubTask.GetFailureCanbeIgnored() {
 				return fmt.Errorf("[%s] sub task was failed", aSubTask.GetName())
 			}
 		}
@@ -329,19 +334,6 @@ func statTask(t Task) error {
 
 	logger.Debug("Start to gen task summary")
 
-	// If the task has sub taks, analyze the status of all of its sub tasks one by one.
-	for _, subTask := range t.GetSubTasks() {
-		if err := statTask(subTask); err != nil {
-			t.SetStatus(TaskFailed)
-			t.SetErr(&pb.Error{
-				Reason: "failed to generate the task summary",
-				Detail: err.Error(),
-			})
-			logger.Error("Finish to gen task summary")
-			return err
-		}
-	}
-
 	successful := 0
 	failed := 0
 	// combined error message in sub tasks and actions
@@ -380,8 +372,47 @@ func statTask(t Task) error {
 		t.SetStatus(TaskSuccessful)
 	}
 
+	// Give a chance to the Processor to process task status, some tasks
+	// have the requirement to redefine task status.
+	if err := processStatus(t); err != nil {
+		t.SetStatus(TaskFailed)
+		t.SetErr(&pb.Error{
+			Reason: "failed to process the task status",
+			Detail: err.Error(),
+		})
+		return err
+	}
+
 	logger.Debug("Finish to gen task summary")
 	return nil
+}
+
+func processStatus(t Task) error {
+	if t == nil {
+		return consts.ErrEmptyTask
+	}
+
+	logger := logrus.WithFields(logrus.Fields{
+		consts.LogFieldTask: t.GetName(),
+	})
+
+	// Create the task processor
+	processor, err := NewProcessor(t.GetType())
+	if err != nil {
+		t.SetErr(&pb.Error{
+			Reason: "failed to create task processor",
+			Detail: err.Error(),
+		})
+		logger.Debug("Failed to create task processor")
+		return err
+	}
+
+	// Check if the processor implemented the StatusHandler interface
+	statusHandler, ok := processor.(StatusHandler)
+	if !ok {
+		return nil
+	}
+	return statusHandler.ProcessStatus(t)
 }
 
 func processExtraResult(t Task) error {
@@ -400,7 +431,7 @@ func processExtraResult(t Task) error {
 			Reason: "failed to create task processor",
 			Detail: err.Error(),
 		})
-		logger.Debug("Failed to split task")
+		logger.Debug("Failed to create task processor")
 		return err
 	}
 

--- a/pkg/deploy/task/task.go
+++ b/pkg/deploy/task/task.go
@@ -41,10 +41,10 @@ type Task interface {
 	GetPriority() int
 	// If a task is not a sub task, this will return ""
 	GetParent() string
-	// FailureCanbeIgnored indicate whether the failure of the task can be ingnored, if yes,
+	// FailureCanBeIgnored indicate whether the failure of the task can be ingnored, if yes,
 	// the task's failure will not affect other task's execution.
-	GetFailureCanbeIgnored() bool
-	SetFailureCanbeIgnored(bool)
+	GetFailureCanBeIgnored() bool
+	SetFailureCanBeIgnored(bool)
 }
 
 // Type represents the type of a task
@@ -73,7 +73,7 @@ type Base struct {
 	SubTasks            []Task
 	Priority            int
 	Parent              string
-	FailureCanbeIgnored bool
+	FailureCanBeIgnored bool
 }
 
 func (b *Base) GetName() string {
@@ -128,12 +128,12 @@ func (b *Base) GetParent() string {
 	return b.Parent
 }
 
-func (b *Base) GetFailureCanbeIgnored() bool {
-	return b.FailureCanbeIgnored
+func (b *Base) GetFailureCanBeIgnored() bool {
+	return b.FailureCanBeIgnored
 }
 
-func (b *Base) SetFailureCanbeIgnored(val bool) {
-	b.FailureCanbeIgnored = val
+func (b *Base) SetFailureCanBeIgnored(val bool) {
+	b.FailureCanBeIgnored = val
 }
 
 // GenTaskLogFileDir is a helper to return the log file dir based on base path and task name

--- a/pkg/deploy/task/task.go
+++ b/pkg/deploy/task/task.go
@@ -41,6 +41,10 @@ type Task interface {
 	GetPriority() int
 	// If a task is not a sub task, this will return ""
 	GetParent() string
+	// FailureCanbeIgnored indicate whether the failure of the task can be ingnored, if yes,
+	// the task's failure will not affect other task's execution.
+	GetFailureCanbeIgnored() bool
+	SetFailureCanbeIgnored(bool)
 }
 
 // Type represents the type of a task
@@ -59,16 +63,17 @@ const (
 )
 
 type Base struct {
-	Name              string
-	TaskType          Type
-	Actions           []action.Action
-	Status            Status
-	Err               *pb.Error
-	LogFileDir        string
-	CreationTimestamp time.Time
-	SubTasks          []Task
-	Priority          int
-	Parent            string
+	Name                string
+	TaskType            Type
+	Actions             []action.Action
+	Status              Status
+	Err                 *pb.Error
+	LogFileDir          string
+	CreationTimestamp   time.Time
+	SubTasks            []Task
+	Priority            int
+	Parent              string
+	FailureCanbeIgnored bool
 }
 
 func (b *Base) GetName() string {
@@ -121,6 +126,14 @@ func (b *Base) GetPriority() int {
 
 func (b *Base) GetParent() string {
 	return b.Parent
+}
+
+func (b *Base) GetFailureCanbeIgnored() bool {
+	return b.FailureCanbeIgnored
+}
+
+func (b *Base) SetFailureCanbeIgnored(val bool) {
+	b.FailureCanbeIgnored = val
 }
 
 // GenTaskLogFileDir is a helper to return the log file dir based on base path and task name


### PR DESCRIPTION


The design is:
1. If any of the node init or deploy etcd tasks failed, the deploy task will fail
2. If the init master task failed, the deploy task will fail
3. If init master task succeeded, but one or more join master tasks failed, the deploy task will continiue to run.
4. For other task failure, the deploy task will continiue to run.