### PR TITLE
fix(deploy): change wait group to channel

### DIFF
--- a/pkg/deploy/action/node_check_executor.go
+++ b/pkg/deploy/action/node_check_executor.go
@@ -501,6 +501,7 @@ func (a *nodeCheckExecutor) Execute(act Action) *pb.Error {
 	go CheckSysManagerExecutor(nodeCheckAction, channel)
 	go CheckPortOccupiedExecutor(nodeCheckAction, channel)
 
+	// update check items
 	for report := range channel {
 		nodeCheckAction.CheckItems = append(nodeCheckAction.CheckItems, report)
 

--- a/pkg/deploy/action/node_check_executor.go
+++ b/pkg/deploy/action/node_check_executor.go
@@ -16,9 +16,10 @@ package action
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"math"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/kpaas-io/kpaas/pkg/constant"
 	"github.com/kpaas-io/kpaas/pkg/deploy"

--- a/pkg/deploy/action/node_check_executor.go
+++ b/pkg/deploy/action/node_check_executor.go
@@ -16,11 +16,9 @@ package action
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"math"
 	"strings"
-	"sync"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/kpaas-io/kpaas/pkg/constant"
 	"github.com/kpaas-io/kpaas/pkg/deploy"
@@ -118,7 +116,7 @@ func newNodeCheckItem(item check.ItemEnum) *NodeCheckItem {
 }
 
 // goroutine as executor for check docker
-func CheckDockerExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckDockerExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -148,15 +146,11 @@ func CheckDockerExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for check CPU
-func CheckCPUExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckCPUExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -203,15 +197,11 @@ func CheckCPUExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for check kernel
-func CheckKernelExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckKernelExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -241,15 +231,11 @@ func CheckKernelExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for check memory
-func CheckMemoryExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckMemoryExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -298,15 +284,11 @@ func CheckMemoryExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for check disk
-func CheckRootDiskExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckRootDiskExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -354,15 +336,11 @@ func CheckRootDiskExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for check distribution
-func CheckDistributionExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckDistributionExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -393,15 +371,11 @@ func CheckDistributionExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for check system preference
-func CheckSysPrefExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckSysPrefExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -425,15 +399,11 @@ func CheckSysPrefExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for check system manager
-func CheckSysManagerExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckSysManagerExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -463,15 +433,11 @@ func CheckSysManagerExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 // goroutine as executor for port occupied check
-func CheckPortOccupiedExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
+func CheckPortOccupiedExecutor(ncAction *NodeCheckAction, ch chan<- *NodeCheckItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":       ncAction.Node.Name,
@@ -504,11 +470,7 @@ func CheckPortOccupiedExecutor(ncAction *NodeCheckAction, wg *sync.WaitGroup) {
 		checkItemReport.Status = ItemDone
 	}
 
-	ncAction.Lock()
-	defer ncAction.Unlock()
-	ncAction.CheckItems = append(ncAction.CheckItems, checkItemReport)
-
-	wg.Done()
+	ch <- checkItemReport
 }
 
 func (a *nodeCheckExecutor) Execute(act Action) *pb.Error {
@@ -521,23 +483,30 @@ func (a *nodeCheckExecutor) Execute(act Action) *pb.Error {
 		consts.LogFieldAction: act.GetName(),
 	})
 
-	var wg sync.WaitGroup
-
 	logger.Debug("Start to execute node check action")
+
+	// make enough length of check items
+	channel := make(chan *NodeCheckItem, 9)
 
 	// check docker, CPU, kernel, memory, disk, distribution, system preference
 	// system manager, port occupied
-	wg.Add(9)
-	go CheckDockerExecutor(nodeCheckAction, &wg)
-	go CheckCPUExecutor(nodeCheckAction, &wg)
-	go CheckKernelExecutor(nodeCheckAction, &wg)
-	go CheckMemoryExecutor(nodeCheckAction, &wg)
-	go CheckRootDiskExecutor(nodeCheckAction, &wg)
-	go CheckDistributionExecutor(nodeCheckAction, &wg)
-	go CheckSysPrefExecutor(nodeCheckAction, &wg)
-	go CheckSysManagerExecutor(nodeCheckAction, &wg)
-	go CheckPortOccupiedExecutor(nodeCheckAction, &wg)
-	wg.Wait()
+	go CheckDockerExecutor(nodeCheckAction, channel)
+	go CheckCPUExecutor(nodeCheckAction, channel)
+	go CheckKernelExecutor(nodeCheckAction, channel)
+	go CheckMemoryExecutor(nodeCheckAction, channel)
+	go CheckRootDiskExecutor(nodeCheckAction, channel)
+	go CheckDistributionExecutor(nodeCheckAction, channel)
+	go CheckSysPrefExecutor(nodeCheckAction, channel)
+	go CheckSysManagerExecutor(nodeCheckAction, channel)
+	go CheckPortOccupiedExecutor(nodeCheckAction, channel)
+
+	for report := range channel {
+		nodeCheckAction.CheckItems = append(nodeCheckAction.CheckItems, report)
+
+		if len(nodeCheckAction.CheckItems) == 9 {
+			break
+		}
+	}
 
 	// If any of check item was failed, we should return an error
 	failedItems := getFailedCheckItems(nodeCheckAction)

--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -132,9 +132,7 @@ func (a *nodeInitExecutor) Execute(act Action) *pb.Error {
 	channel := make(chan *NodeInitItem, len(initGroup))
 
 	for item := range initGroup {
-		if initGroup[item] == true {
-			go InitAsyncExecutor(item, nodeInitAction, channel)
-		}
+		go InitAsyncExecutor(item, nodeInitAction, channel)
 	}
 
 	// update init items

--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -89,7 +89,7 @@ func newNodeInitItem(item it.ItemEnum) *NodeInitItem {
 }
 
 // goroutine exec item init event and write to channel
-func InitAsyncExecute(item it.ItemEnum, ncAction *NodeInitAction, ch chan<- *NodeInitItem) {
+func InitAsyncExecutor(item it.ItemEnum, ncAction *NodeInitAction, ch chan<- *NodeInitItem) {
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":      ncAction.Node.GetName(),
@@ -133,10 +133,11 @@ func (a *nodeInitExecutor) Execute(act Action) *pb.Error {
 
 	for item := range initGroup {
 		if initGroup[item] == true {
-			go InitAsyncExecute(item, nodeInitAction, channel)
+			go InitAsyncExecutor(item, nodeInitAction, channel)
 		}
 	}
 
+	// update init items
 	for report := range channel {
 		nodeInitAction.InitItems = append(nodeInitAction.InitItems, report)
 

--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -16,8 +16,9 @@ package action
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/kpaas-io/kpaas/pkg/constant"
 	"github.com/kpaas-io/kpaas/pkg/deploy/consts"


### PR DESCRIPTION
之前的设计是用锁共同修改一个 *NodeInitAction.InitItem 和 *NodeCheckAction.CheckItem 不太符合 golang 的风格
--
优化:
改变之前的 wait group 和锁
修改范围包含 check items 和 init items