### PR TITLE
feat(deploy/init): add init log #OTWO-13

### DIFF
--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -131,18 +131,15 @@ func (a *nodeInitExecutor) Execute(act Action) *pb.Error {
 	logger.Debug("Start to execute node init action")
 
 	executeLogBuf := act.GetExecuteLogBuffer()
-	if executeLogBuf == nil {
-		logrus.Error("init log buffer is empty")
-		return &pb.Error{
-			Reason:     "init log buffer is empty",
-			Detail:     "init log buffer can not be empty",
-			FixMethods: "please ensure init log buffer is initialized",
-		}
-	}
 
 	initGroup := constructInitGroup(nodeInitAction)
 	if len(initGroup) == 0 {
-		logger.Error("initialization item group is empty")
+		logger.Error("item initialization group is empty")
+		return &pb.Error{
+			Reason:     "init group is empty",
+			Detail:     "init group can not be empty",
+			FixMethods: "add init item into init group",
+		}
 	}
 
 	// make enough length of init items
@@ -165,13 +162,15 @@ func (a *nodeInitExecutor) Execute(act Action) *pb.Error {
 		}
 	}
 
-	// write to log file
 	var initCount int
-	for logs := range logChan {
-		initCount++
-		io.Copy(executeLogBuf, logs)
-		if initCount == len(initGroup) {
-			break
+	if executeLogBuf != nil {
+		for logs := range logChan {
+			initCount++
+			// write to log file
+			io.Copy(executeLogBuf, logs)
+			if initCount == len(initGroup) {
+				break
+			}
 		}
 	}
 

--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -15,8 +15,10 @@
 package action
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 
@@ -25,12 +27,15 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/operation"
 	it "github.com/kpaas-io/kpaas/pkg/deploy/operation/init"
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
+	"io"
 )
 
 const (
 	InitPassed = "init passed"
 	InitFailed = "init failed"
 )
+
+var initWg sync.WaitGroup
 
 func init() {
 	RegisterExecutor(ActionTypeNodeInit, new(nodeInitExecutor))
@@ -39,7 +44,7 @@ func init() {
 type nodeInitExecutor struct{}
 
 // due to items, ItemInitScripts exec remote scripts and return std, report, error
-func ExecuteInitScript(item it.ItemEnum, action *NodeInitAction, initItemReport *NodeInitItem) (string, *NodeInitItem, error) {
+func ExecuteInitScript(item it.ItemEnum, action *NodeInitAction, initItemReport *NodeInitItem, logChan chan<- *bytes.Buffer) (string, *NodeInitItem, error) {
 	logger := logrus.WithFields(logrus.Fields{
 		"node":      action.Node.GetName(),
 		"init_item": item,
@@ -63,7 +68,7 @@ func ExecuteInitScript(item it.ItemEnum, action *NodeInitAction, initItemReport 
 		return "", initItemReport, fmt.Errorf("fail to construct init %v operation for node %v: ", item, action.Node.Name)
 	}
 
-	stdOut, stdErr, err := initItem.RunCommands(action.Node, initAction)
+	stdOut, stdErr, err := initItem.RunCommands(action.Node, initAction, logChan)
 	if err != nil {
 		logger.Errorf("can not execute init %v operation command, err: %v", item, err)
 		initItemReport.Status = ItemFailed
@@ -89,7 +94,9 @@ func newNodeInitItem(item it.ItemEnum) *NodeInitItem {
 }
 
 // goroutine exec item init event and write to channel
-func InitAsyncExecutor(item it.ItemEnum, ncAction *NodeInitAction, ch chan<- *NodeInitItem) {
+func InitAsyncExecutor(item it.ItemEnum, ncAction *NodeInitAction, ch chan<- *NodeInitItem, logChan chan<- *bytes.Buffer) {
+
+	defer initWg.Done()
 
 	logger := logrus.WithFields(logrus.Fields{
 		"node":      ncAction.Node.GetName(),
@@ -99,7 +106,7 @@ func InitAsyncExecutor(item it.ItemEnum, ncAction *NodeInitAction, ch chan<- *No
 	logger.Debugf("Start to execute init")
 
 	initItemReport := newNodeInitItem(item)
-	_, initItemReport, err := ExecuteInitScript(item, ncAction, initItemReport)
+	_, initItemReport, err := ExecuteInitScript(item, ncAction, initItemReport, logChan)
 	if err != nil {
 		logger.Errorf("%v: %v", InitFailed, err)
 		initItemReport.Status = ItemFailed
@@ -123,23 +130,47 @@ func (a *nodeInitExecutor) Execute(act Action) *pb.Error {
 	})
 	logger.Debug("Start to execute node init action")
 
+	executeLogBuf := act.GetExecuteLogBuffer()
+	if executeLogBuf == nil {
+		logrus.Error("init log buffer is empty")
+		return &pb.Error{
+			Reason:     "init log buffer is empty",
+			Detail:     "init log buffer can not be empty",
+			FixMethods: "please ensure init log buffer is initialized",
+		}
+	}
+
 	initGroup := constructInitGroup(nodeInitAction)
 	if len(initGroup) == 0 {
 		logger.Error("initialization item group is empty")
 	}
 
 	// make enough length of init items
-	channel := make(chan *NodeInitItem, len(initGroup))
+	initChan := make(chan *NodeInitItem, len(initGroup))
+	logChan := make(chan *bytes.Buffer, len(initGroup))
 
 	for item := range initGroup {
-		go InitAsyncExecutor(item, nodeInitAction, channel)
+		initWg.Add(1)
+		go InitAsyncExecutor(item, nodeInitAction, initChan, logChan)
 	}
 
+	initWg.Wait()
+
 	// update init items
-	for report := range channel {
+	for report := range initChan {
 		nodeInitAction.InitItems = append(nodeInitAction.InitItems, report)
 
 		if len(nodeInitAction.InitItems) == len(initGroup) {
+			break
+		}
+	}
+
+	// write to log file
+	var initCount int
+	for logs := range logChan {
+		initCount++
+		io.Copy(executeLogBuf, logs)
+		if initCount == len(initGroup) {
 			break
 		}
 	}

--- a/pkg/deploy/action/node_init_executor.go
+++ b/pkg/deploy/action/node_init_executor.go
@@ -17,6 +17,7 @@ package action
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/kpaas-io/kpaas/pkg/deploy/operation"
 	it "github.com/kpaas-io/kpaas/pkg/deploy/operation/init"
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
-	"io"
 )
 
 const (

--- a/pkg/deploy/operation/init/common.go
+++ b/pkg/deploy/operation/init/common.go
@@ -15,6 +15,8 @@
 package init
 
 import (
+	"bytes"
+
 	"github.com/kpaas-io/kpaas/pkg/deploy/operation"
 	pb "github.com/kpaas-io/kpaas/pkg/deploy/protos"
 )
@@ -24,7 +26,7 @@ type ItemEnum string
 type OperationsGenerator struct{}
 
 type InitOperation interface {
-	RunCommands(config *pb.Node, initAction *operation.NodeInitAction) ([]byte, []byte, error)
+	RunCommands(config *pb.Node, initAction *operation.NodeInitAction, logChan chan<- *bytes.Buffer) ([]byte, []byte, error)
 }
 
 const (

--- a/pkg/deploy/operation/init/init_change_alias.go
+++ b/pkg/deploy/operation/init/init_change_alias.go
@@ -15,6 +15,8 @@
 package init
 
 import (
+	"bytes"
+
 	"github.com/kpaas-io/kpaas/pkg/deploy/assets"
 	"github.com/kpaas-io/kpaas/pkg/deploy/command"
 	"github.com/kpaas-io/kpaas/pkg/deploy/machine"
@@ -27,16 +29,18 @@ const (
 )
 
 type InitHostaliasOperation struct {
-	operation.BaseOperation
+	shellCmd       *command.ShellCommand
 	NodeInitAction *operation.NodeInitAction
 }
 
-func (itOps *InitHostaliasOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction) (stdOut, stdErr []byte, err error) {
+func (itOps *InitHostaliasOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction, logChan chan<- *bytes.Buffer) (stdOut, stdErr []byte, err error) {
 
 	m, err := machine.NewMachine(node)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	logBuffer := &bytes.Buffer{}
 
 	itOps.NodeInitAction = initAction
 
@@ -55,10 +59,15 @@ func (itOps *InitHostaliasOperation) RunCommands(node *pb.Node, initAction *oper
 		return nil, nil, err
 	}
 
-	itOps.AddCommands(command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+hostAliasScript))
+	itOps.shellCmd = command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+hostAliasScript).
+		WithDescription("初始化变更 alias").
+		WithExecuteLogWriter(logBuffer)
 
 	// run commands
-	stdOut, stdErr, err = itOps.Do()
+	stdOut, stdErr, err = itOps.shellCmd.Execute()
+
+	// write to log channel
+	logChan <- logBuffer
 
 	return
 }

--- a/pkg/deploy/operation/init/init_change_firewall.go
+++ b/pkg/deploy/operation/init/init_change_firewall.go
@@ -15,6 +15,8 @@
 package init
 
 import (
+	"bytes"
+
 	"github.com/kpaas-io/kpaas/pkg/deploy/assets"
 	"github.com/kpaas-io/kpaas/pkg/deploy/command"
 	"github.com/kpaas-io/kpaas/pkg/deploy/machine"
@@ -27,16 +29,18 @@ const (
 )
 
 type InitFireWallOperation struct {
-	operation.BaseOperation
+	shellCmd       *command.ShellCommand
 	NodeInitAction *operation.NodeInitAction
 }
 
-func (itOps *InitFireWallOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction) (stdOut, stdErr []byte, err error) {
+func (itOps *InitFireWallOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction, logChan chan<- *bytes.Buffer) (stdOut, stdErr []byte, err error) {
 
 	m, err := machine.NewMachine(node)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	logBuffer := &bytes.Buffer{}
 
 	itOps.NodeInitAction = initAction
 
@@ -55,9 +59,16 @@ func (itOps *InitFireWallOperation) RunCommands(node *pb.Node, initAction *opera
 		return nil, nil, err
 	}
 
-	itOps.AddCommands(command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+fireWallScript))
+	// construct init firewall commands
+	itOps.shellCmd = command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+fireWallScript).
+		WithDescription("初始化关闭防火墙").
+		WithExecuteLogWriter(logBuffer)
 
-	stdOut, stdErr, err = itOps.Do()
+	// execute commands
+	stdOut, stdErr, err = itOps.shellCmd.Execute()
+
+	// write to log channel
+	logChan <- logBuffer
 
 	return
 }

--- a/pkg/deploy/operation/init/init_change_network.go
+++ b/pkg/deploy/operation/init/init_change_network.go
@@ -15,6 +15,8 @@
 package init
 
 import (
+	"bytes"
+
 	"github.com/kpaas-io/kpaas/pkg/deploy/assets"
 	"github.com/kpaas-io/kpaas/pkg/deploy/command"
 	"github.com/kpaas-io/kpaas/pkg/deploy/machine"
@@ -27,16 +29,18 @@ const (
 )
 
 type InitNetworkOperation struct {
-	operation.BaseOperation
+	shellCmd       *command.ShellCommand
 	NodeInitAction *operation.NodeInitAction
 }
 
-func (itOps *InitNetworkOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction) (stdOut, stdErr []byte, err error) {
+func (itOps *InitNetworkOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction, logChan chan<- *bytes.Buffer) (stdOut, stdErr []byte, err error) {
 
 	m, err := machine.NewMachine(node)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	logBuffer := &bytes.Buffer{}
 
 	itOps.NodeInitAction = initAction
 
@@ -55,10 +59,15 @@ func (itOps *InitNetworkOperation) RunCommands(node *pb.Node, initAction *operat
 		return nil, nil, err
 	}
 
-	itOps.AddCommands(command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+networkScript))
+	itOps.shellCmd = command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+networkScript).
+		WithDescription("初始化网络配置").
+		WithExecuteLogWriter(logBuffer)
 
 	// run commands
-	stdOut, stdErr, err = itOps.Do()
+	stdOut, stdErr, err = itOps.shellCmd.Execute()
+
+	// write to log channel
+	logChan <- logBuffer
 
 	return
 }

--- a/pkg/deploy/operation/init/init_change_route.go
+++ b/pkg/deploy/operation/init/init_change_route.go
@@ -15,6 +15,8 @@
 package init
 
 import (
+	"bytes"
+
 	"github.com/kpaas-io/kpaas/pkg/deploy/assets"
 	"github.com/kpaas-io/kpaas/pkg/deploy/command"
 	"github.com/kpaas-io/kpaas/pkg/deploy/machine"
@@ -27,16 +29,18 @@ const (
 )
 
 type InitRouteOperation struct {
-	operation.BaseOperation
+	shellCmd       *command.ShellCommand
 	NodeInitAction *operation.NodeInitAction
 }
 
-func (itOps *InitRouteOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction) (stdOut, stdErr []byte, err error) {
+func (itOps *InitRouteOperation) RunCommands(node *pb.Node, initAction *operation.NodeInitAction, logChan chan<- *bytes.Buffer) (stdOut, stdErr []byte, err error) {
 
 	m, err := machine.NewMachine(node)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	logBuffer := &bytes.Buffer{}
 
 	itOps.NodeInitAction = initAction
 
@@ -55,10 +59,15 @@ func (itOps *InitRouteOperation) RunCommands(node *pb.Node, initAction *operatio
 		return nil, nil, err
 	}
 
-	itOps.AddCommands(command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+routeScript))
+	itOps.shellCmd = command.NewShellCommand(m, "bash", operation.InitRemoteScriptPath+routeScript).
+		WithDescription("初始化路由表").
+		WithExecuteLogWriter(logBuffer)
 
 	// run commands
-	stdOut, stdErr, err = itOps.Do()
+	stdOut, stdErr, err = itOps.shellCmd.Execute()
+
+	// write to log channel
+	logChan <- logBuffer
 
 	return
 }


### PR DESCRIPTION
1. 添加 init log
2. 与 check log 方法相同，go func() 的日志打到统一的 init channel 中，对于每个 action(node)，有且唯一一个 executeLogWriter，统一收集 init channel 写入