### PR TITLE
fix: add ClusterRoleBinding for calico-node

### DIFF
--- a/charts/calico/templates/rbac.yaml
+++ b/charts/calico/templates/rbac.yaml
@@ -237,3 +237,18 @@ rules:
     verbs:
       - get
 {{- end }}
+
+--- 
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system


### PR DESCRIPTION
- add missing part in calico charts:  ClusterRoleBinding `calico-node` of `rbac.yaml`